### PR TITLE
Fix logic on when btn-size class is added to button

### DIFF
--- a/R/input-dropdown.R
+++ b/R/input-dropdown.R
@@ -71,7 +71,7 @@ dropdownButton <- function(..., circle = TRUE, status = "default",
   } else {
     html_button <- list(
       class = paste0("btn btn-", status," action-button dropdown-toggle "),
-      class = if (size == "default") paste0("btn-", size),
+      class = if (size != "default") paste0("btn-", size),
       type = "button",
       id = inputId,
       `data-toggle` = "dropdown",


### PR DESCRIPTION
Hi dreamRs,

Just a small patch to fix the logic on the creation of the 'btn-size' class for the 'dropdown' widget.

Mike