### PR TITLE
pass false when none selected in pickerInput

### DIFF
--- a/inst/www/selectPicker/picker-bindings.js
+++ b/inst/www/selectPicker/picker-bindings.js
@@ -22,7 +22,7 @@ var pickerInputBinding = new Shiny.InputBinding();
       return el.id;
     },
     getValue: function getValue(el) {
-      return $(el).val();
+      return $(el).val() || false;
     },
     setValue: function setValue(el, value) {
       $(el).val(value);

--- a/inst/www/selectPicker/picker-bindings.js
+++ b/inst/www/selectPicker/picker-bindings.js
@@ -22,7 +22,7 @@ var pickerInputBinding = new Shiny.InputBinding();
       return el.id;
     },
     getValue: function getValue(el) {
-      return $(el).val() || false;
+      return $(el).val() || [""];
     },
     setValue: function setValue(el, value) {
       $(el).val(value);


### PR DESCRIPTION
First of all, thanks so much for your work on `shinyWidgets`.

### issue

I discovered that when none are selected in the `pickerInput` no event is triggered in Shiny.  For instance,

```
library(shiny)
library(shinyWidgets)
library(htmltools)

ui <- fluidPage(
  fluidRow(
    column(
      width = 6,
      pickerInput("cyl", label = "cylinder", choices = sort(unique(mtcars$cyl)), 
                  selected = sort(unique(mtcars$cyl)), multiple = TRUE, width='100%',
                  options = list(`actions-box` = TRUE, size=8,
                                 `style` = "selectize-input",
                                 `count-selected-text` = "{0} cylinder",
                                 `deselect-all-text` = "None",
                                 `select-all-text` = "All"))
    )
  )
)

server <- function(input, output, session) {
  observeEvent(input$cyl, {
    print(input$cyl)
  })
}

shinyApp(ui, server)
```

![pickerinput](https://user-images.githubusercontent.com/837910/36946764-874a7046-1f87-11e8-8453-27e9f916485b.gif)

### proposed solution

Passing ~~`false`~~ `[""]` seems to fix the problem.  While this seems to work in all my tests, there might be additional downstream issues that I might be missing.  I originally chose `false` which works, but I realized that `false` might be a selection in a rare case, so I changed to `[""]`.

![pickerinput2](https://user-images.githubusercontent.com/837910/36946786-f9242766-1f87-11e8-93a6-133591affece.gif)


