### PR TITLE
updateRadioGroupButtons: Add as.character to selected value

### DIFF
--- a/R/input-radiogroupbuttons.R
+++ b/R/input-radiogroupbuttons.R
@@ -222,8 +222,11 @@ updateRadioGroupButtons <- function(session, inputId, label = NULL, choices = NU
                                     status = "default", size = "normal",
                                     checkIcon = list(), choiceNames = NULL, choiceValues = NULL) {
   args <- normalizeChoicesArgs(choices, choiceNames, choiceValues, mustExist = FALSE)
-  if (is.null(selected) && !is.null(args$choiceValues))
+  if (is.null(selected) && !is.null(args$choiceValues)) {
     selected <- args$choiceValues[[1]]
+  } else {
+    selected <- as.character(selected)
+  }
   options <- if (!is.null(args$choiceValues)) {
     format(htmltools::tagList(generateRGB(session$ns(inputId), args, selected, status = status, size = size,
                                checkIcon = checkIcon)))


### PR DESCRIPTION
I finally found out what was my problem and corrected it in this pull request.  
If I define a numeric value in `selected` for the `updateRadioGroupButtons`, this value is accounted for the button to be active but does not update the `input$value`.  
In the classical `radioGroupButtons`, this selected value is transformed `as.character` prior to update.  
Here is a reproducible example (Press "go" to use the update):
```r
# devtools::install_github("dreamRs/shinyWidgets")

mod_testUI <- function(id) {
  ns <- NS(id)
  tabItem(
    tabName = "test",
    box(
      radioGroupButtons(
        # radioButtons(
        inputId = ns("bouton"),
        label = "Choisir :",
        choices = c("2007", "2008"),
        selected = 2007
      ),
      column(12, style = "font-weight:bold;color:red;",
             textOutput(ns("out_text"))),
      actionButton(ns("go"), "Go")
    ))
}

mod_test <- function(input, output, session) {
  
  
  observeEvent(input$go,{
  updateRadioGroupButtons(
    # updateRadioButtons(
    session, "bouton",
    choices = c(10, "A", "B", "ok"),
    selected = 10
  )
    })
  
  output$out_text <- renderText({
    paste(input$bouton)
  })
  
}

library(shiny)
library(shinyWidgets)
library(shinydashboard)

if (interactive()) {
  ui <- fluidPage(
    mod_testUI("plop")
  )
  
  server <- function(input, output, session) {
    callModule(mod_test, "plop")
  }
  
  shinyApp(ui, server)
}
```