### PR TITLE
Fix display issues with shiny 1.2

### DIFF
--- a/inst/www/awesomeRadioCheckbox/css/awesome-bootstrap-checkbox-shiny.css
+++ b/inst/www/awesomeRadioCheckbox/css/awesome-bootstrap-checkbox-shiny.css
@@ -51,8 +51,9 @@
 }
 .checkbox-bs input[type="checkbox"]:checked + label::after,
 .checkbox-bs input[type="radio"]:checked + label::after {
-  font-family: "FontAwesome";
+  font-family: "Font Awesome 5 Free";
   content: "\f00c";
+  font-weight: 900;
 }
 .checkbox-bs input[type="checkbox"]:indeterminate + label::after,
 .checkbox-bs input[type="radio"]:indeterminate + label::after {


### PR DESCRIPTION
shiny 1.2 upgraded FontAwesome to 5.3.1
Proper display requires changes in the CSS

See here:
https://fontawesome.com/v5.3.1/how-to-use/on-the-web/setup/upgrading-from-version-4