### PR TITLE
Add margin for dropdownButton content

### DIFF
--- a/R/input-dropdown.R
+++ b/R/input-dropdown.R
@@ -14,6 +14,7 @@
 #' @param right Logical. The dropdown menu starts on the right.
 #' @param up Logical. Display the dropdown menu above.
 #' @param width Width of the dropdown menu content.
+#' @param margin Value of the dropdown margin-right and margin-left menu content.
 #' @param inputId Optional, id for the button, the button act like an \code{actionButton},
 #' and you can use the id to toggle the dropdown menu server-side with \code{\link{toggleDropdownButton}}.
 #'
@@ -85,7 +86,7 @@ dropdownButton <- function(..., circle = TRUE, status = "default",
                            size = "default", icon = NULL,
                            label = NULL, tooltip = FALSE,
                            right = FALSE, up = FALSE,
-                           width = NULL, inputId = NULL) {
+                           width = NULL, margin = "10px", inputId = NULL) {
   size <- match.arg(arg = size, choices = c("default", "lg", "sm", "xs"))
   if (is.null(inputId)) {
     inputId <- paste0("drop", sample.int(1e9, 1))
@@ -99,8 +100,9 @@ dropdownButton <- function(..., circle = TRUE, status = "default",
     style = if (!is.null(width))
       paste0("width: ", htmltools::validateCssUnit(width), ";"),
     `aria-labelledby` = inputId,
-    lapply(X = list(...), FUN = htmltools::tags$li, style =
-             "margin-left: 10px; margin-right: 10px;")
+    lapply(X = list(...), FUN = htmltools::tags$li, 
+        style = paste0("margin-left: ", htmltools::validateCssUnit(margin), 
+        "; margin-right: ", htmltools::validateCssUnit(margin), ";"))
   )
 
   # button

--- a/man/dropdownButton.Rd
+++ b/man/dropdownButton.Rd
@@ -6,7 +6,8 @@
 \usage{
 dropdownButton(..., circle = TRUE, status = "default",
   size = "default", icon = NULL, label = NULL, tooltip = FALSE,
-  right = FALSE, up = FALSE, width = NULL, inputId = NULL)
+  right = FALSE, up = FALSE, width = NULL, margin = "10px",
+  inputId = NULL)
 }
 \arguments{
 \item{...}{List of tag to be displayed into the dropdown menu.}
@@ -29,6 +30,8 @@ Or use an arbitrary strings to add a custom class, e.g. : with \code{status = 'm
 \item{up}{Logical. Display the dropdown menu above.}
 
 \item{width}{Width of the dropdown menu content.}
+
+\item{margin}{Value of the dropdown margin-right and margin-left menu content.}
 
 \item{inputId}{Optional, id for the button, the button act like an \code{actionButton},
 and you can use the id to toggle the dropdown menu server-side with \code{\link{toggleDropdownButton}}.}


### PR DESCRIPTION
Add parameter `margin` to dropdownButton :

````
dropdownButton(
    circle = FALSE,
    label = "Examples",
    margin = "0",
    tags$a(href="#", "Example 1"),
    tags$a(href="#", "Exemple 2"),
    tags$a(href="#", "Exemple 3")
)
````

Will return

![image](https://user-images.githubusercontent.com/26872734/54136558-55c11100-441c-11e9-94d6-fecbe5cc1681.png)

instead of 

![image](https://user-images.githubusercontent.com/26872734/54136578-5d80b580-441c-11e9-8f5c-9395301445b0.png)

Default to `10px` as original behavior