### PR TITLE
patch to fix flipBox issue (not flipping outside shinydashboardPlus)

### DIFF
--- a/R/useShinydashboardPlus.R
+++ b/R/useShinydashboardPlus.R
@@ -200,6 +200,6 @@ useShinydashboardPlus <- function() {
     sidebar = shinydashboard::dashboardSidebar(),
     body = shinydashboard::dashboardBody()
   ))
-  attachDependencies(tags$div(), value = deps)
+  attachDependencies(tags$div(class = "main-sidebar", style = "display: none;"), value = deps)
 }
 


### PR DESCRIPTION
Simple patch to make `flipBox()` flipping when used with `useShinyDashboardPlus`.