### PR TITLE
enable dropdownButton as an inline component (span instead of div)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyWidgets
 Title: Custom Inputs Widgets for Shiny
-Version: 0.4.8.960
+Version: 0.4.8.970
 Authors@R: c(
   person("Victor", "Perrier", email = "victor.perrier@dreamrs.fr", role = c("aut", "cre")),
   person("Fanny", "Meyer", email = "fanny.meyer@dreamrs.fr", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ shinyWidgets 0.4.8.900
 * Update to SweetAlert2: more options available for `sendSweetAlert`, `confirmSweetAlert`, `inputSweetAlert`.
 * add `useTablerDash` to inport functions from tablerDash.
 * `updateProgressBar`, `confirmSweetAlert`, `inputSweetAlert` are now module friendly, thanks to [@AshesITR](https://github.com/AshesITR).
+* add `inline` argument to dropdownButton: return either a span or a div element
 
 
 shinyWidgets 0.4.8

--- a/R/input-dropdown.R
+++ b/R/input-dropdown.R
@@ -15,6 +15,7 @@
 #' @param up Logical. Display the dropdown menu above.
 #' @param width Width of the dropdown menu content.
 #' @param margin Value of the dropdown margin-right and margin-left menu content.
+#' @param inline use an inline (\code{span()}) or block container (\code{div()}) for the output.
 #' @param inputId Optional, id for the button, the button act like an \code{actionButton},
 #' and you can use the id to toggle the dropdown menu server-side with \code{\link{toggleDropdownButton}}.
 #'
@@ -86,7 +87,7 @@ dropdownButton <- function(..., circle = TRUE, status = "default",
                            size = "default", icon = NULL,
                            label = NULL, tooltip = FALSE,
                            right = FALSE, up = FALSE,
-                           width = NULL, margin = "10px", inputId = NULL) {
+                           width = NULL, margin = "10px", inline = FALSE, inputId = NULL) {
   size <- match.arg(arg = size, choices = c("default", "lg", "sm", "xs"))
   if (is.null(inputId)) {
     inputId <- paste0("drop", sample.int(1e9, 1))
@@ -100,8 +101,8 @@ dropdownButton <- function(..., circle = TRUE, status = "default",
     style = if (!is.null(width))
       paste0("width: ", htmltools::validateCssUnit(width), ";"),
     `aria-labelledby` = inputId,
-    lapply(X = list(...), FUN = htmltools::tags$li, 
-        style = paste0("margin-left: ", htmltools::validateCssUnit(margin), 
+    lapply(X = list(...), FUN = htmltools::tags$li,
+        style = paste0("margin-left: ", htmltools::validateCssUnit(margin),
         "; margin-right: ", htmltools::validateCssUnit(margin), ";"))
   )
 
@@ -149,7 +150,9 @@ dropdownButton <- function(..., circle = TRUE, status = "default",
     tooltipJs <- ""
   }
 
-  dropdownTag <- htmltools::tags$div(
+  if( inline ) container <- htmltools::tags$span
+  else container <- htmltools::tags$div
+  dropdownTag <- container(
     class = ifelse(up, "dropup", "dropdown"),
     class = "btn-dropdown-input",
     html_button, id = paste0(inputId, "_state"),

--- a/man/dropdownButton.Rd
+++ b/man/dropdownButton.Rd
@@ -7,7 +7,7 @@
 dropdownButton(..., circle = TRUE, status = "default",
   size = "default", icon = NULL, label = NULL, tooltip = FALSE,
   right = FALSE, up = FALSE, width = NULL, margin = "10px",
-  inputId = NULL)
+  inline = FALSE, inputId = NULL)
 }
 \arguments{
 \item{...}{List of tag to be displayed into the dropdown menu.}
@@ -32,6 +32,8 @@ Or use an arbitrary strings to add a custom class, e.g. : with \code{status = 'm
 \item{width}{Width of the dropdown menu content.}
 
 \item{margin}{Value of the dropdown margin-right and margin-left menu content.}
+
+\item{inline}{use an inline (\code{span()}) or block container (\code{div()}) for the output.}
 
 \item{inputId}{Optional, id for the button, the button act like an \code{actionButton},
 and you can use the id to toggle the dropdown menu server-side with \code{\link{toggleDropdownButton}}.}


### PR DESCRIPTION
Hello,

La modif permet en indiquant `inline=TRUE` de récupérer le dropdownButton dans un `span` au lieu d'un `div` - sur le même modele que `shiny::textOutput`.

Cela permet surtout d'enchaîner facilement plusieurs `dropdownButton` en ligne.