### PR TITLE
Update input-radiogroupbuttons.R

### DIFF
--- a/R/input-checkboxgroupbuttons.R
+++ b/R/input-checkboxgroupbuttons.R
@@ -80,7 +80,6 @@ checkboxGroupButtons <- function(
     if (!is.null(label)) htmltools::tags$br(),
     htmltools::tags$div(
       id=inputId, class="checkboxGroupButtons",
-      style = "margin-top: 3px; margin-bottom: 3px;",
       style=if (justified) "width: 100%;",
       htmltools::tags$div(
         class=divClass, role="group", `aria-label`="...", `data-toggle`="buttons",

--- a/R/input-radiogroupbuttons.R
+++ b/R/input-radiogroupbuttons.R
@@ -82,7 +82,6 @@ radioGroupButtons <- function(
     if (!is.null(label)) htmltools::tags$br(),
     htmltools::tags$div(
       id=inputId, class="radioGroupButtons",
-      style="margin-top: 3px; margin-bottom: 3px; ",
       style=if (justified) "width: 100%;",
       htmltools::tags$div(
         class=divClass, role="group", `aria-label`="...", `data-toggle`="buttons",


### PR DESCRIPTION
I'd like to suggest removing this extraneous 3px margin. As was pointed out in https://github.com/dreamRs/shinyWidgets/issues/113 this creates alignment issues when using radio group buttons together with other inputs.

Thanks for your work on this great package!