### PR TITLE
Add SHIFT-selection

### DIFF
--- a/R/input-selectpicker.R
+++ b/R/input-selectpicker.R
@@ -374,12 +374,14 @@ pickerSelectOptions <- function(choices, selected = NULL, choicesOpt = NULL, max
   }
   if (is.null(choicesOpt))
     choicesOpt <- list()
-  l <- sapply(choices, length)
+  l <- lengths(choices)
   if (!is.null(maxOptGroup))
     maxOptGroup <- rep_len(x = maxOptGroup, length.out = sum(l))
-  m <- matrix(data = c(c(1, cumsum(l)[-length(l)] + 1), cumsum(l)), ncol = 2)
-  html <- lapply(seq_along(choices), FUN = function(i) {
-    label <- names(choices)[i]
+  cusum <- cumsum(l)
+  m <- matrix(data = c(1, cusum[-length(l)] + 1, cusum), ncol = 2)
+  namesch <- names(choices)
+  html <- lapply(seq_len(length(choices)), FUN = function(i) {
+    label <- namesch[i]
     choice <- choices[[i]]
     if (is.list(choice)) {
       tags$optgroup(

--- a/R/input-selectpicker.R
+++ b/R/input-selectpicker.R
@@ -355,7 +355,7 @@ updatePickerInput <- function (session, inputId, label = NULL, selected = NULL, 
 #'
 #' @param choices a named list
 #' @param selected selected value if any
-#' @param choicesOpt additional option ofr choices
+#' @param choicesOpt additional option for choices
 #'
 #' @importFrom htmltools HTML htmlEscape tagList
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,8 +5,11 @@
 
 
 # dropNulls
+# dropNulls <- function(x) {
+#   x[!vapply(x, is.null, FUN.VALUE = logical(1))]
+# }
 dropNulls <- function(x) {
-  x[!vapply(x, is.null, FUN.VALUE = logical(1))]
+  x[lengths(x) != 0]
 }
 
 dropNullsOrNA <- function(x) {

--- a/inst/www/selectPicker/js/bootstrap-select.min.js
+++ b/inst/www/selectPicker/js/bootstrap-select.min.js
@@ -1172,25 +1172,18 @@
                 }), this.$menu.on("click", ".actions-btn", function(e) {
                     C.options.liveSearch ? C.$searchbox.trigger("focus") : C.$button.trigger("focus"), e.preventDefault(), e.stopPropagation(), z(this).hasClass("bs-select-all") ? C.selectAll() : C.deselectAll()
                 }), this.$element.on("change" + U, function() {
-                        //console.log("change");
                         if (C.clickinfo && C.multiple) {
                             if (C.clickinfo.shiftKey) {
-                                //console.log("C"); console.log(C);
-                                //console.log("T"); console.log(T);
                                 if (T[1] && T[2].length != 0) {
+                                    var k = C.selectpicker.current.data;
+
                                     // This was just selected
-                                    var selshift = C.$element[0].options[T[0]].value
+                                    var selshift = k[T[0]].text
 
                                 	// This was selected previously
-                                	var selprevshift = "";
-                                	for (i = 1; i < C.$element[0].options.length; i++) {
-                                		var tmp = C.$element[0].options[i].value;
-                                		if (tmp == T[2][T[2].length-1]) {
-                                			selprevshift = i;
-                                		}
-                                	}
-                                	//console.log("selshift " + T[0])
-                                	//console.log("selprevshift " + selprevshift)
+                                	var selprevshift = k.filter(function(ki) {
+                                        return ki.text === T[2][T[2].length-1];
+                                    })[0].index;
 
                                     // get Indices of selections
                                 	var indexarr = {};
@@ -1204,17 +1197,17 @@
                                 	}
 
                                     // Get Text of selections
-                                	//console.log("indexarr " + indexarr);
                                 	var selectext = [];
-                                	for (i = 0; i < indexarr.length; i++) {
-                                		var obj = C.selectpicker.current.data[indexarr[i]].text;
-                                		selectext.push(obj);
+                                	for (var i = 0; i < indexarr.length; i++) {
+                                		selectext.push(k[indexarr[i]].text);
                                 	}
+
+                                    // Add previous selections if available
                                 	if (T[2].length > 1) {
-                                	    T[2].pop();
                                 	    selectext = selectext.concat(T[2]);
                                 	}
 
+                                    // Select items
                                 	C.val(selectext);
                                 }
                             }
@@ -1261,7 +1254,6 @@
                 return this.options.liveSearchStyle || "contains"
             },
             val: function(e) {
-                    //console.log("val: ", e)
                 var t = this.$element[0];
                 if (void 0 === e) return this.$element.val();
                 var i = O(t);
@@ -1296,7 +1288,6 @@
                 return this.changeAll(!1)
             },
             toggle: function(e) {
-                    //console.log("toggle: " + e)
                 (e = e || window.event) && e.stopPropagation(), this.$button.trigger("click.bs.dropdown.data-api")
             },
             keydown: function(e) {

--- a/inst/www/selectPicker/js/bootstrap-select.min.js
+++ b/inst/www/selectPicker/js/bootstrap-select.min.js
@@ -5,5 +5,1364 @@
  * Licensed under MIT (https://github.com/snapappointments/bootstrap-select/blob/master/LICENSE)
  */
 
-!function(e,t){void 0===e&&void 0!==window&&(e=window),"function"==typeof define&&define.amd?define(["jquery"],function(e){return t(e)}):"object"==typeof module&&module.exports?module.exports=t(require("jquery")):t(e.jQuery)}(this,function(e){!function(z){"use strict";var d=["sanitize","whiteList","sanitizeFn"],r=["background","cite","href","itemtype","longdesc","poster","src","xlink:href"],e={"*":["class","dir","id","lang","role","tabindex","style",/^aria-[\w-]*$/i],a:["target","href","title","rel"],area:[],b:[],br:[],col:[],code:[],div:[],em:[],hr:[],h1:[],h2:[],h3:[],h4:[],h5:[],h6:[],i:[],img:["src","alt","title","width","height"],li:[],ol:[],p:[],pre:[],s:[],small:[],span:[],sub:[],sup:[],strong:[],u:[],ul:[]},l=/^(?:(?:https?|mailto|ftp|tel|file):|[^&:/?#]*(?:[/?#]|$))/gi,a=/^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+/]+=*$/i;function v(e,t){var i=e.nodeName.toLowerCase();if(-1!==z.inArray(i,t))return-1===z.inArray(i,r)||Boolean(e.nodeValue.match(l)||e.nodeValue.match(a));for(var s=z(t).filter(function(e,t){return t instanceof RegExp}),n=0,o=s.length;n<o;n++)if(i.match(s[n]))return!0;return!1}function P(e,t,i){if(i&&"function"==typeof i)return i(e);for(var s=Object.keys(t),n=0,o=e.length;n<o;n++)for(var r=e[n].querySelectorAll("*"),l=0,a=r.length;l<a;l++){var c=r[l],d=c.nodeName.toLowerCase();if(-1!==s.indexOf(d))for(var h=[].slice.call(c.attributes),p=[].concat(t["*"]||[],t[d]||[]),u=0,f=h.length;u<f;u++){var m=h[u];v(m,p)||c.removeAttribute(m.nodeName)}else c.parentNode.removeChild(c)}}"classList"in document.createElement("_")||function(e){if("Element"in e){var t="classList",i="prototype",s=e.Element[i],n=Object,o=function(){var i=z(this);return{add:function(e){return e=Array.prototype.slice.call(arguments).join(" "),i.addClass(e)},remove:function(e){return e=Array.prototype.slice.call(arguments).join(" "),i.removeClass(e)},toggle:function(e,t){return i.toggleClass(e,t)},contains:function(e){return i.hasClass(e)}}};if(n.defineProperty){var r={get:o,enumerable:!0,configurable:!0};try{n.defineProperty(s,t,r)}catch(e){void 0!==e.number&&-2146823252!==e.number||(r.enumerable=!1,n.defineProperty(s,t,r))}}else n[i].__defineGetter__&&s.__defineGetter__(t,o)}}(window);var t,c,i,s=document.createElement("_");if(s.classList.add("c1","c2"),!s.classList.contains("c2")){var n=DOMTokenList.prototype.add,o=DOMTokenList.prototype.remove;DOMTokenList.prototype.add=function(){Array.prototype.forEach.call(arguments,n.bind(this))},DOMTokenList.prototype.remove=function(){Array.prototype.forEach.call(arguments,o.bind(this))}}if(s.classList.toggle("c3",!1),s.classList.contains("c3")){var h=DOMTokenList.prototype.toggle;DOMTokenList.prototype.toggle=function(e,t){return 1 in arguments&&!this.contains(e)==!t?t:h.call(this,e)}}function O(e,t){for(var i,s=[],n=t||e.selectedOptions,o=0,r=n.length;o<r;o++)(i=n[o]).disabled||"OPTGROUP"===i.parentNode.tagName&&i.parentNode.disabled||s.push(i.value||i.text);return e.multiple?s:s.length?s[0]:null}s=null,String.prototype.startsWith||(t=function(){try{var e={},t=Object.defineProperty,i=t(e,e,e)&&t}catch(e){}return i}(),c={}.toString,i=function(e){if(null==this)throw new TypeError;var t=String(this);if(e&&"[object RegExp]"==c.call(e))throw new TypeError;var i=t.length,s=String(e),n=s.length,o=1<arguments.length?arguments[1]:void 0,r=o?Number(o):0;r!=r&&(r=0);var l=Math.min(Math.max(r,0),i);if(i<n+l)return!1;for(var a=-1;++a<n;)if(t.charCodeAt(l+a)!=s.charCodeAt(a))return!1;return!0},t?t(String.prototype,"startsWith",{value:i,configurable:!0,writable:!0}):String.prototype.startsWith=i),Object.keys||(Object.keys=function(e,t,i){for(t in i=[],e)i.hasOwnProperty.call(e,t)&&i.push(t);return i}),HTMLSelectElement&&!HTMLSelectElement.prototype.hasOwnProperty("selectedOptions")&&Object.defineProperty(HTMLSelectElement.prototype,"selectedOptions",{get:function(){return this.querySelectorAll(":checked")}});var p={useDefault:!1,_set:z.valHooks.select.set};z.valHooks.select.set=function(e,t){return t&&!p.useDefault&&z(e).data("selected",!0),p._set.apply(this,arguments)};var T=null,u=function(){try{return new Event("change"),!0}catch(e){return!1}}();function k(e,t,i,s){for(var n=["display","subtext","tokens"],o=!1,r=0;r<n.length;r++){var l=n[r],a=e[l];if(a&&(a=a.toString(),"display"===l&&(a=a.replace(/<[^>]+>/g,"")),s&&(a=w(a)),a=a.toUpperCase(),o="contains"===i?0<=a.indexOf(t):a.startsWith(t)))break}return o}function A(e){return parseInt(e,10)||0}z.fn.triggerNative=function(e){var t,i=this[0];i.dispatchEvent?(u?t=new Event(e,{bubbles:!0}):(t=document.createEvent("Event")).initEvent(e,!0,!1),i.dispatchEvent(t)):i.fireEvent?((t=document.createEventObject()).eventType=e,i.fireEvent("on"+e,t)):this.trigger(e)};var f={"\xc0":"A","\xc1":"A","\xc2":"A","\xc3":"A","\xc4":"A","\xc5":"A","\xe0":"a","\xe1":"a","\xe2":"a","\xe3":"a","\xe4":"a","\xe5":"a","\xc7":"C","\xe7":"c","\xd0":"D","\xf0":"d","\xc8":"E","\xc9":"E","\xca":"E","\xcb":"E","\xe8":"e","\xe9":"e","\xea":"e","\xeb":"e","\xcc":"I","\xcd":"I","\xce":"I","\xcf":"I","\xec":"i","\xed":"i","\xee":"i","\xef":"i","\xd1":"N","\xf1":"n","\xd2":"O","\xd3":"O","\xd4":"O","\xd5":"O","\xd6":"O","\xd8":"O","\xf2":"o","\xf3":"o","\xf4":"o","\xf5":"o","\xf6":"o","\xf8":"o","\xd9":"U","\xda":"U","\xdb":"U","\xdc":"U","\xf9":"u","\xfa":"u","\xfb":"u","\xfc":"u","\xdd":"Y","\xfd":"y","\xff":"y","\xc6":"Ae","\xe6":"ae","\xde":"Th","\xfe":"th","\xdf":"ss","\u0100":"A","\u0102":"A","\u0104":"A","\u0101":"a","\u0103":"a","\u0105":"a","\u0106":"C","\u0108":"C","\u010a":"C","\u010c":"C","\u0107":"c","\u0109":"c","\u010b":"c","\u010d":"c","\u010e":"D","\u0110":"D","\u010f":"d","\u0111":"d","\u0112":"E","\u0114":"E","\u0116":"E","\u0118":"E","\u011a":"E","\u0113":"e","\u0115":"e","\u0117":"e","\u0119":"e","\u011b":"e","\u011c":"G","\u011e":"G","\u0120":"G","\u0122":"G","\u011d":"g","\u011f":"g","\u0121":"g","\u0123":"g","\u0124":"H","\u0126":"H","\u0125":"h","\u0127":"h","\u0128":"I","\u012a":"I","\u012c":"I","\u012e":"I","\u0130":"I","\u0129":"i","\u012b":"i","\u012d":"i","\u012f":"i","\u0131":"i","\u0134":"J","\u0135":"j","\u0136":"K","\u0137":"k","\u0138":"k","\u0139":"L","\u013b":"L","\u013d":"L","\u013f":"L","\u0141":"L","\u013a":"l","\u013c":"l","\u013e":"l","\u0140":"l","\u0142":"l","\u0143":"N","\u0145":"N","\u0147":"N","\u014a":"N","\u0144":"n","\u0146":"n","\u0148":"n","\u014b":"n","\u014c":"O","\u014e":"O","\u0150":"O","\u014d":"o","\u014f":"o","\u0151":"o","\u0154":"R","\u0156":"R","\u0158":"R","\u0155":"r","\u0157":"r","\u0159":"r","\u015a":"S","\u015c":"S","\u015e":"S","\u0160":"S","\u015b":"s","\u015d":"s","\u015f":"s","\u0161":"s","\u0162":"T","\u0164":"T","\u0166":"T","\u0163":"t","\u0165":"t","\u0167":"t","\u0168":"U","\u016a":"U","\u016c":"U","\u016e":"U","\u0170":"U","\u0172":"U","\u0169":"u","\u016b":"u","\u016d":"u","\u016f":"u","\u0171":"u","\u0173":"u","\u0174":"W","\u0175":"w","\u0176":"Y","\u0177":"y","\u0178":"Y","\u0179":"Z","\u017b":"Z","\u017d":"Z","\u017a":"z","\u017c":"z","\u017e":"z","\u0132":"IJ","\u0133":"ij","\u0152":"Oe","\u0153":"oe","\u0149":"'n","\u017f":"s"},m=/[\xc0-\xd6\xd8-\xf6\xf8-\xff\u0100-\u017f]/g,g=RegExp("[\\u0300-\\u036f\\ufe20-\\ufe2f\\u20d0-\\u20ff\\u1ab0-\\u1aff\\u1dc0-\\u1dff]","g");function b(e){return f[e]}function w(e){return(e=e.toString())&&e.replace(m,b).replace(g,"")}var I,x,$,y,S,E=(I={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#x27;","`":"&#x60;"},x=function(e){return I[e]},$="(?:"+Object.keys(I).join("|")+")",y=RegExp($),S=RegExp($,"g"),function(e){return e=null==e?"":""+e,y.test(e)?e.replace(S,x):e}),C={32:" ",48:"0",49:"1",50:"2",51:"3",52:"4",53:"5",54:"6",55:"7",56:"8",57:"9",59:";",65:"A",66:"B",67:"C",68:"D",69:"E",70:"F",71:"G",72:"H",73:"I",74:"J",75:"K",76:"L",77:"M",78:"N",79:"O",80:"P",81:"Q",82:"R",83:"S",84:"T",85:"U",86:"V",87:"W",88:"X",89:"Y",90:"Z",96:"0",97:"1",98:"2",99:"3",100:"4",101:"5",102:"6",103:"7",104:"8",105:"9"},L=27,N=13,D=32,H=9,B=38,W=40,M={success:!1,major:"3"};try{M.full=(z.fn.dropdown.Constructor.VERSION||"").split(" ")[0].split("."),M.major=M.full[0],M.success=!0}catch(e){}var R=0,U=".bs.select",j={DISABLED:"disabled",DIVIDER:"divider",SHOW:"open",DROPUP:"dropup",MENU:"dropdown-menu",MENURIGHT:"dropdown-menu-right",MENULEFT:"dropdown-menu-left",BUTTONCLASS:"btn-default",POPOVERHEADER:"popover-title",ICONBASE:"glyphicon",TICKICON:"glyphicon-ok"},V={MENU:"."+j.MENU},F={span:document.createElement("span"),i:document.createElement("i"),subtext:document.createElement("small"),a:document.createElement("a"),li:document.createElement("li"),whitespace:document.createTextNode("\xa0"),fragment:document.createDocumentFragment()};F.a.setAttribute("role","option"),F.subtext.className="text-muted",F.text=F.span.cloneNode(!1),F.text.className="text",F.checkMark=F.span.cloneNode(!1);var _=new RegExp(B+"|"+W),G=new RegExp("^"+H+"$|"+L),q=function(e,t,i){var s=F.li.cloneNode(!1);return e&&(1===e.nodeType||11===e.nodeType?s.appendChild(e):s.innerHTML=e),void 0!==t&&""!==t&&(s.className=t),null!=i&&s.classList.add("optgroup-"+i),s},K=function(e,t,i){var s=F.a.cloneNode(!0);return e&&(11===e.nodeType?s.appendChild(e):s.insertAdjacentHTML("beforeend",e)),void 0!==t&&""!==t&&(s.className=t),"4"===M.major&&s.classList.add("dropdown-item"),i&&s.setAttribute("style",i),s},Y=function(e,t){var i,s,n=F.text.cloneNode(!1);if(e.content)n.innerHTML=e.content;else{if(n.textContent=e.text,e.icon){var o=F.whitespace.cloneNode(!1);(s=(!0===t?F.i:F.span).cloneNode(!1)).className=e.iconBase+" "+e.icon,F.fragment.appendChild(s),F.fragment.appendChild(o)}e.subtext&&((i=F.subtext.cloneNode(!1)).textContent=e.subtext,n.appendChild(i))}if(!0===t)for(;0<n.childNodes.length;)F.fragment.appendChild(n.childNodes[0]);else F.fragment.appendChild(n);return F.fragment},Z=function(e){var t,i,s=F.text.cloneNode(!1);if(s.innerHTML=e.label,e.icon){var n=F.whitespace.cloneNode(!1);(i=F.span.cloneNode(!1)).className=e.iconBase+" "+e.icon,F.fragment.appendChild(i),F.fragment.appendChild(n)}return e.subtext&&((t=F.subtext.cloneNode(!1)).textContent=e.subtext,s.appendChild(t)),F.fragment.appendChild(s),F.fragment},J=function(e,t){var i=this;p.useDefault||(z.valHooks.select.set=p._set,p.useDefault=!0),this.$element=z(e),this.$newElement=null,this.$button=null,this.$menu=null,this.options=t,this.selectpicker={main:{},search:{},current:{},view:{},keydown:{keyHistory:"",resetKeyHistory:{start:function(){return setTimeout(function(){i.selectpicker.keydown.keyHistory=""},800)}}}},null===this.options.title&&(this.options.title=this.$element.attr("title"));var s=this.options.windowPadding;"number"==typeof s&&(this.options.windowPadding=[s,s,s,s]),this.val=J.prototype.val,this.render=J.prototype.render,this.refresh=J.prototype.refresh,this.setStyle=J.prototype.setStyle,this.selectAll=J.prototype.selectAll,this.deselectAll=J.prototype.deselectAll,this.destroy=J.prototype.destroy,this.remove=J.prototype.remove,this.show=J.prototype.show,this.hide=J.prototype.hide,this.init()};function Q(e){var l,a=arguments,c=e;if([].shift.apply(a),!M.success){try{M.full=(z.fn.dropdown.Constructor.VERSION||"").split(" ")[0].split(".")}catch(e){J.BootstrapVersion?M.full=J.BootstrapVersion.split(" ")[0].split("."):(M.full=[M.major,"0","0"],console.warn("There was an issue retrieving Bootstrap's version. Ensure Bootstrap is being loaded before bootstrap-select and there is no namespace collision. If loading Bootstrap asynchronously, the version may need to be manually specified via $.fn.selectpicker.Constructor.BootstrapVersion.",e))}M.major=M.full[0],M.success=!0}if("4"===M.major){var t=[];J.DEFAULTS.style===j.BUTTONCLASS&&t.push({name:"style",className:"BUTTONCLASS"}),J.DEFAULTS.iconBase===j.ICONBASE&&t.push({name:"iconBase",className:"ICONBASE"}),J.DEFAULTS.tickIcon===j.TICKICON&&t.push({name:"tickIcon",className:"TICKICON"}),j.DIVIDER="dropdown-divider",j.SHOW="show",j.BUTTONCLASS="btn-light",j.POPOVERHEADER="popover-header",j.ICONBASE="",j.TICKICON="bs-ok-default";for(var i=0;i<t.length;i++){e=t[i];J.DEFAULTS[e.name]=j[e.className]}}var s=this.each(function(){var e=z(this);if(e.is("select")){var t=e.data("selectpicker"),i="object"==typeof c&&c;if(t){if(i)for(var s in i)i.hasOwnProperty(s)&&(t.options[s]=i[s])}else{var n=e.data();for(var o in n)n.hasOwnProperty(o)&&-1!==z.inArray(o,d)&&delete n[o];var r=z.extend({},J.DEFAULTS,z.fn.selectpicker.defaults||{},n,i);r.template=z.extend({},J.DEFAULTS.template,z.fn.selectpicker.defaults?z.fn.selectpicker.defaults.template:{},n.template,i.template),e.data("selectpicker",t=new J(this,r))}"string"==typeof c&&(l=t[c]instanceof Function?t[c].apply(t,a):t.options[c])}});return void 0!==l?l:s}J.VERSION="1.13.10",J.DEFAULTS={noneSelectedText:"Nothing selected",noneResultsText:"No results matched {0}",countSelectedText:function(e,t){return 1==e?"{0} item selected":"{0} items selected"},maxOptionsText:function(e,t){return[1==e?"Limit reached ({n} item max)":"Limit reached ({n} items max)",1==t?"Group limit reached ({n} item max)":"Group limit reached ({n} items max)"]},selectAllText:"Select All",deselectAllText:"Deselect All",doneButton:!1,doneButtonText:"Close",multipleSeparator:", ",styleBase:"btn",style:j.BUTTONCLASS,size:"auto",title:null,selectedTextFormat:"values",width:!1,container:!1,hideDisabled:!1,showSubtext:!1,showIcon:!0,showContent:!0,dropupAuto:!0,header:!1,liveSearch:!1,liveSearchPlaceholder:null,liveSearchNormalize:!1,liveSearchStyle:"contains",actionsBox:!1,iconBase:j.ICONBASE,tickIcon:j.TICKICON,showTick:!1,template:{caret:'<span class="caret"></span>'},maxOptions:!1,mobile:!1,selectOnTab:!1,dropdownAlignRight:!1,windowPadding:0,virtualScroll:600,display:!1,sanitize:!0,sanitizeFn:null,whiteList:e},J.prototype={constructor:J,init:function(){var i=this,e=this.$element.attr("id");R++,this.selectId="bs-select-"+R,this.$element[0].classList.add("bs-select-hidden"),this.multiple=this.$element.prop("multiple"),this.autofocus=this.$element.prop("autofocus"),this.$element[0].classList.contains("show-tick")&&(this.options.showTick=!0),this.$newElement=this.createDropdown(),this.$element.after(this.$newElement).prependTo(this.$newElement),this.$button=this.$newElement.children("button"),this.$menu=this.$newElement.children(V.MENU),this.$menuInner=this.$menu.children(".inner"),this.$searchbox=this.$menu.find("input"),this.$element[0].classList.remove("bs-select-hidden"),!0===this.options.dropdownAlignRight&&this.$menu[0].classList.add(j.MENURIGHT),void 0!==e&&this.$button.attr("data-id",e),this.checkDisabled(),this.clickListener(),this.options.liveSearch?(this.liveSearchListener(),this.focusedParent=this.$searchbox[0]):this.focusedParent=this.$menuInner[0],this.setStyle(),this.render(),this.setWidth(),this.options.container?this.selectPosition():this.$element.on("hide"+U,function(){if(i.isVirtual()){var e=i.$menuInner[0],t=e.firstChild.cloneNode(!1);e.replaceChild(t,e.firstChild),e.scrollTop=0}}),this.$menu.data("this",this),this.$newElement.data("this",this),this.options.mobile&&this.mobile(),this.$newElement.on({"hide.bs.dropdown":function(e){i.$element.trigger("hide"+U,e)},"hidden.bs.dropdown":function(e){i.$element.trigger("hidden"+U,e)},"show.bs.dropdown":function(e){i.$element.trigger("show"+U,e)},"shown.bs.dropdown":function(e){i.$element.trigger("shown"+U,e)}}),i.$element[0].hasAttribute("required")&&this.$element.on("invalid"+U,function(){i.$button[0].classList.add("bs-invalid"),i.$element.on("shown"+U+".invalid",function(){i.$element.val(i.$element.val()).off("shown"+U+".invalid")}).on("rendered"+U,function(){this.validity.valid&&i.$button[0].classList.remove("bs-invalid"),i.$element.off("rendered"+U)}),i.$button.on("blur"+U,function(){i.$element.trigger("focus").trigger("blur"),i.$button.off("blur"+U)})}),setTimeout(function(){i.createLi(),i.$element.trigger("loaded"+U)})},createDropdown:function(){var e=this.multiple||this.options.showTick?" show-tick":"",t=this.multiple?' aria-multiselectable="true"':"",i="",s=this.autofocus?" autofocus":"";M.major<4&&this.$element.parent().hasClass("input-group")&&(i=" input-group-btn");var n,o="",r="",l="",a="";return this.options.header&&(o='<div class="'+j.POPOVERHEADER+'"><button type="button" class="close" aria-hidden="true">&times;</button>'+this.options.header+"</div>"),this.options.liveSearch&&(r='<div class="bs-searchbox"><input type="text" class="form-control" autocomplete="off"'+(null===this.options.liveSearchPlaceholder?"":' placeholder="'+E(this.options.liveSearchPlaceholder)+'"')+' role="combobox" aria-label="Search" aria-controls="'+this.selectId+'" aria-autocomplete="list"></div>'),this.multiple&&this.options.actionsBox&&(l='<div class="bs-actionsbox"><div class="btn-group btn-group-sm btn-block"><button type="button" class="actions-btn bs-select-all btn '+j.BUTTONCLASS+'">'+this.options.selectAllText+'</button><button type="button" class="actions-btn bs-deselect-all btn '+j.BUTTONCLASS+'">'+this.options.deselectAllText+"</button></div></div>"),this.multiple&&this.options.doneButton&&(a='<div class="bs-donebutton"><div class="btn-group btn-block"><button type="button" class="btn btn-sm '+j.BUTTONCLASS+'">'+this.options.doneButtonText+"</button></div></div>"),n='<div class="dropdown bootstrap-select'+e+i+'"><button type="button" class="'+this.options.styleBase+' dropdown-toggle" '+("static"===this.options.display?'data-display="static"':"")+'data-toggle="dropdown"'+s+' role="combobox" aria-owns="'+this.selectId+'" aria-haspopup="listbox" aria-expanded="false"><div class="filter-option"><div class="filter-option-inner"><div class="filter-option-inner-inner"></div></div> </div>'+("4"===M.major?"":'<span class="bs-caret">'+this.options.template.caret+"</span>")+'</button><div class="'+j.MENU+" "+("4"===M.major?"":j.SHOW)+'">'+o+r+l+'<div class="inner '+j.SHOW+'" role="listbox" id="'+this.selectId+'" tabindex="-1" '+t+'><ul class="'+j.MENU+" inner "+("4"===M.major?j.SHOW:"")+'" role="presentation"></ul></div>'+a+"</div></div>",z(n)},setPositionData:function(){this.selectpicker.view.canHighlight=[];for(var e=this.selectpicker.view.size=0;e<this.selectpicker.current.data.length;e++){var t=this.selectpicker.current.data[e],i=!0;"divider"===t.type?(i=!1,t.height=this.sizeInfo.dividerHeight):"optgroup-label"===t.type?(i=!1,t.height=this.sizeInfo.dropdownHeaderHeight):t.height=this.sizeInfo.liHeight,t.disabled&&(i=!1),this.selectpicker.view.canHighlight.push(i),i&&(this.selectpicker.view.size++,t.posinset=this.selectpicker.view.size),t.position=(0===e?0:this.selectpicker.current.data[e-1].position)+t.height}},isVirtual:function(){return!1!==this.options.virtualScroll&&this.selectpicker.main.elements.length>=this.options.virtualScroll||!0===this.options.virtualScroll},createView:function(A,e,t){var L,N,D=this,i=0,H=[];if(this.selectpicker.current=A?this.selectpicker.search:this.selectpicker.main,this.setPositionData(),e)if(t)i=this.$menuInner[0].scrollTop;else if(!D.multiple){var s=D.$element[0],n=(s.options[s.selectedIndex]||{}).liIndex;if("number"==typeof n&&!1!==D.options.size){var o=D.selectpicker.main.data[n],r=o&&o.position;r&&(i=r-(D.sizeInfo.menuInnerHeight+D.sizeInfo.liHeight)/2)}}function l(e,t){var i,s,n,o,r,l,a,c,d,h,p=D.selectpicker.current.elements.length,u=[],f=!0,m=D.isVirtual();D.selectpicker.view.scrollTop=e,!0===m&&D.sizeInfo.hasScrollBar&&D.$menu[0].offsetWidth>D.sizeInfo.totalMenuWidth&&(D.sizeInfo.menuWidth=D.$menu[0].offsetWidth,D.sizeInfo.totalMenuWidth=D.sizeInfo.menuWidth+D.sizeInfo.scrollBarWidth,D.$menu.css("min-width",D.sizeInfo.menuWidth)),i=Math.ceil(D.sizeInfo.menuInnerHeight/D.sizeInfo.liHeight*1.5),s=Math.round(p/i)||1;for(var v=0;v<s;v++){var g=(v+1)*i;if(v===s-1&&(g=p),u[v]=[v*i+(v?1:0),g],!p)break;void 0===r&&e<=D.selectpicker.current.data[g-1].position-D.sizeInfo.menuInnerHeight&&(r=v)}if(void 0===r&&(r=0),l=[D.selectpicker.view.position0,D.selectpicker.view.position1],n=Math.max(0,r-1),o=Math.min(s-1,r+1),D.selectpicker.view.position0=!1===m?0:Math.max(0,u[n][0])||0,D.selectpicker.view.position1=!1===m?p:Math.min(p,u[o][1])||0,a=l[0]!==D.selectpicker.view.position0||l[1]!==D.selectpicker.view.position1,void 0!==D.activeIndex&&(N=D.selectpicker.main.elements[D.prevActiveIndex],H=D.selectpicker.main.elements[D.activeIndex],L=D.selectpicker.main.elements[D.selectedIndex],t&&(D.activeIndex!==D.selectedIndex&&D.defocusItem(H),D.activeIndex=void 0),D.activeIndex&&D.activeIndex!==D.selectedIndex&&D.defocusItem(L)),void 0!==D.prevActiveIndex&&D.prevActiveIndex!==D.activeIndex&&D.prevActiveIndex!==D.selectedIndex&&D.defocusItem(N),(t||a)&&(c=D.selectpicker.view.visibleElements?D.selectpicker.view.visibleElements.slice():[],D.selectpicker.view.visibleElements=!1===m?D.selectpicker.current.elements:D.selectpicker.current.elements.slice(D.selectpicker.view.position0,D.selectpicker.view.position1),D.setOptionStatus(),(A||!1===m&&t)&&(d=c,h=D.selectpicker.view.visibleElements,f=!(d.length===h.length&&d.every(function(e,t){return e===h[t]}))),(t||!0===m)&&f)){var b,w,I=D.$menuInner[0],x=document.createDocumentFragment(),k=I.firstChild.cloneNode(!1),$=D.selectpicker.view.visibleElements,y=[];I.replaceChild(k,I.firstChild);v=0;for(var S=$.length;v<S;v++){var E,C,O=$[v];D.options.sanitize&&(E=O.lastChild)&&(C=D.selectpicker.current.data[v+D.selectpicker.view.position0])&&C.content&&!C.sanitized&&(y.push(E),C.sanitized=!0),x.appendChild(O)}D.options.sanitize&&y.length&&P(y,D.options.whiteList,D.options.sanitizeFn),I.firstChild.style.marginBottom=!0===m?(b=0===D.selectpicker.view.position0?0:D.selectpicker.current.data[D.selectpicker.view.position0-1].position,w=D.selectpicker.view.position1>p-1?0:D.selectpicker.current.data[p-1].position-D.selectpicker.current.data[D.selectpicker.view.position1-1].position,I.firstChild.style.marginTop=b+"px",w+"px"):I.firstChild.style.marginTop=0,I.firstChild.appendChild(x)}if(D.prevActiveIndex=D.activeIndex,D.options.liveSearch){if(A&&t){var z,T=0;D.selectpicker.view.canHighlight[T]||(T=1+D.selectpicker.view.canHighlight.slice(1).indexOf(!0)),z=D.selectpicker.view.visibleElements[T],D.defocusItem(D.selectpicker.view.currentActive),D.activeIndex=(D.selectpicker.current.data[T]||{}).index,D.focusItem(z)}}else D.$menuInner.trigger("focus")}l(i,!0),this.$menuInner.off("scroll.createView").on("scroll.createView",function(e,t){D.noScroll||l(this.scrollTop,t),D.noScroll=!1}),z(window).off("resize"+U+"."+this.selectId+".createView").on("resize"+U+"."+this.selectId+".createView",function(){D.$newElement.hasClass(j.SHOW)&&l(D.$menuInner[0].scrollTop)})},focusItem:function(e,t,i){if(e){t=t||this.selectpicker.main.data[this.activeIndex];var s=e.firstChild;s&&(s.setAttribute("aria-setsize",this.selectpicker.view.size),s.setAttribute("aria-posinset",t.posinset),!0!==i&&(this.focusedParent.setAttribute("aria-activedescendant",s.id),e.classList.add("active"),s.classList.add("active")))}},defocusItem:function(e){e&&(e.classList.remove("active"),e.firstChild&&e.firstChild.classList.remove("active"))},setPlaceholder:function(){var e=!1;if(this.options.title&&!this.multiple){this.selectpicker.view.titleOption||(this.selectpicker.view.titleOption=document.createElement("option")),e=!0;var t=this.$element[0],i=!1,s=!this.selectpicker.view.titleOption.parentNode;if(s)this.selectpicker.view.titleOption.className="bs-title-option",this.selectpicker.view.titleOption.value="",i=void 0===z(t.options[t.selectedIndex]).attr("selected")&&void 0===this.$element.data("selected");(s||0!==this.selectpicker.view.titleOption.index)&&t.insertBefore(this.selectpicker.view.titleOption,t.firstChild),i&&(t.selectedIndex=0)}return e},createLi:function(){var c=this,f=this.options.iconBase,m=':not([hidden]):not([data-hidden="true"])',v=[],g=[],d=0,b=0,e=this.setPlaceholder()?1:0;this.options.hideDisabled&&(m+=":not(:disabled)"),!c.options.showTick&&!c.multiple||F.checkMark.parentNode||(F.checkMark.className=f+" "+c.options.tickIcon+" check-mark",F.a.appendChild(F.checkMark));var t=this.$element[0].querySelectorAll("select > *"+m);function w(e){var t=g[g.length-1];t&&"divider"===t.type&&(t.optID||e.optID)||((e=e||{}).type="divider",v.push(q(!1,j.DIVIDER,e.optID?e.optID+"div":void 0)),g.push(e))}function I(e,t){if((t=t||{}).divider="true"===e.getAttribute("data-divider"),t.divider)w({optID:t.optID});else{var i=g.length,s=e.style.cssText,n=s?E(s):"",o=(e.className||"")+(t.optgroupClass||"");t.optID&&(o="opt "+o),t.text=e.textContent,t.content=e.getAttribute("data-content"),t.tokens=e.getAttribute("data-tokens"),t.subtext=e.getAttribute("data-subtext"),t.icon=e.getAttribute("data-icon"),t.iconBase=f;var r=Y(t),l=q(K(r,o,n),"",t.optID);l.firstChild&&(l.firstChild.id=c.selectId+"-"+i),v.push(l),e.liIndex=i,t.display=t.content||t.text,t.type="option",t.index=i,t.option=e,t.disabled=t.disabled||e.disabled,g.push(t);var a=0;t.display&&(a+=t.display.length),t.subtext&&(a+=t.subtext.length),t.icon&&(a+=1),d<a&&(d=a,c.selectpicker.view.widestOption=v[v.length-1])}}function i(e,t){var i=t[e],s=t[e-1],n=t[e+1],o=i.querySelectorAll("option"+m);if(o.length){var r,l,a={label:E(i.label),subtext:i.getAttribute("data-subtext"),icon:i.getAttribute("data-icon"),iconBase:f},c=" "+(i.className||"");b++,s&&w({optID:b});var d=Z(a);v.push(q(d,"dropdown-header"+c,b)),g.push({display:a.label,subtext:a.subtext,type:"optgroup-label",optID:b});for(var h=0,p=o.length;h<p;h++){var u=o[h];0===h&&(l=(r=g.length-1)+p),I(u,{headerIndex:r,lastIndex:l,optID:b,optgroupClass:c,disabled:i.disabled})}n&&w({optID:b})}}for(var s=t.length;e<s;e++){var n=t[e];"OPTGROUP"!==n.tagName?I(n,{}):i(e,t)}this.selectpicker.main.elements=v,this.selectpicker.main.data=g,this.selectpicker.current=this.selectpicker.main},findLis:function(){return this.$menuInner.find(".inner > li")},render:function(){this.setPlaceholder();var e,t,i=this,s=this.$element[0],n=function(e,t){var i,s=e.selectedOptions,n=[];if(t){for(var o=0,r=s.length;o<r;o++)(i=s[o]).disabled||"OPTGROUP"===i.parentNode.tagName&&i.parentNode.disabled||n.push(i);return n}return s}(s,this.options.hideDisabled),o=n.length,r=this.$button[0],l=r.querySelector(".filter-option-inner-inner"),a=document.createTextNode(this.options.multipleSeparator),c=F.fragment.cloneNode(!1),d=!1;if(r.classList.toggle("bs-placeholder",i.multiple?!o:!O(s,n)),this.tabIndex(),"static"===this.options.selectedTextFormat)c=Y({text:this.options.title},!0);else if((e=this.multiple&&-1!==this.options.selectedTextFormat.indexOf("count")&&1<o)&&(e=1<(t=this.options.selectedTextFormat.split(">")).length&&o>t[1]||1===t.length&&2<=o),!1===e){for(var h=0;h<o&&h<50;h++){var p=n[h],u={},f={content:p.getAttribute("data-content"),subtext:p.getAttribute("data-subtext"),icon:p.getAttribute("data-icon")};this.multiple&&0<h&&c.appendChild(a.cloneNode(!1)),p.title?u.text=p.title:f.content&&i.options.showContent?(u.content=f.content.toString(),d=!0):(i.options.showIcon&&(u.icon=f.icon,u.iconBase=this.options.iconBase),i.options.showSubtext&&!i.multiple&&f.subtext&&(u.subtext=" "+f.subtext),u.text=p.textContent.trim()),c.appendChild(Y(u,!0))}49<o&&c.appendChild(document.createTextNode("..."))}else{var m=':not([hidden]):not([data-hidden="true"]):not([data-divider="true"])';this.options.hideDisabled&&(m+=":not(:disabled)");var v=this.$element[0].querySelectorAll("select > option"+m+", optgroup"+m+" option"+m).length,g="function"==typeof this.options.countSelectedText?this.options.countSelectedText(o,v):this.options.countSelectedText;c=Y({text:g.replace("{0}",o.toString()).replace("{1}",v.toString())},!0)}if(null==this.options.title&&(this.options.title=this.$element.attr("title")),c.childNodes.length||(c=Y({text:void 0!==this.options.title?this.options.title:this.options.noneSelectedText},!0)),r.title=c.textContent.replace(/<[^>]*>?/g,"").trim(),this.options.sanitize&&d&&P([c],i.options.whiteList,i.options.sanitizeFn),l.innerHTML="",l.appendChild(c),M.major<4&&this.$newElement[0].classList.contains("bs3-has-addon")){var b=r.querySelector(".filter-expand"),w=l.cloneNode(!0);w.className="filter-expand",b?r.replaceChild(w,b):r.appendChild(w)}this.$element.trigger("rendered"+U)},setStyle:function(e,t){var i,s=this.$button[0],n=this.$newElement[0],o=this.options.style.trim();this.$element.attr("class")&&this.$newElement.addClass(this.$element.attr("class").replace(/selectpicker|mobile-device|bs-select-hidden|validate\[.*\]/gi,"")),M.major<4&&(n.classList.add("bs3"),n.parentNode.classList.contains("input-group")&&(n.previousElementSibling||n.nextElementSibling)&&(n.previousElementSibling||n.nextElementSibling).classList.contains("input-group-addon")&&n.classList.add("bs3-has-addon")),i=e?e.trim():o,"add"==t?i&&s.classList.add.apply(s.classList,i.split(" ")):"remove"==t?i&&s.classList.remove.apply(s.classList,i.split(" ")):(o&&s.classList.remove.apply(s.classList,o.split(" ")),i&&s.classList.add.apply(s.classList,i.split(" ")))},liHeight:function(e){if(e||!1!==this.options.size&&!this.sizeInfo){this.sizeInfo||(this.sizeInfo={});var t=document.createElement("div"),i=document.createElement("div"),s=document.createElement("div"),n=document.createElement("ul"),o=document.createElement("li"),r=document.createElement("li"),l=document.createElement("li"),a=document.createElement("a"),c=document.createElement("span"),d=this.options.header&&0<this.$menu.find("."+j.POPOVERHEADER).length?this.$menu.find("."+j.POPOVERHEADER)[0].cloneNode(!0):null,h=this.options.liveSearch?document.createElement("div"):null,p=this.options.actionsBox&&this.multiple&&0<this.$menu.find(".bs-actionsbox").length?this.$menu.find(".bs-actionsbox")[0].cloneNode(!0):null,u=this.options.doneButton&&this.multiple&&0<this.$menu.find(".bs-donebutton").length?this.$menu.find(".bs-donebutton")[0].cloneNode(!0):null,f=this.$element.find("option")[0];if(this.sizeInfo.selectWidth=this.$newElement[0].offsetWidth,c.className="text",a.className="dropdown-item "+(f?f.className:""),t.className=this.$menu[0].parentNode.className+" "+j.SHOW,t.style.width=this.sizeInfo.selectWidth+"px","auto"===this.options.width&&(i.style.minWidth=0),i.className=j.MENU+" "+j.SHOW,s.className="inner "+j.SHOW,n.className=j.MENU+" inner "+("4"===M.major?j.SHOW:""),o.className=j.DIVIDER,r.className="dropdown-header",c.appendChild(document.createTextNode("\u200b")),a.appendChild(c),l.appendChild(a),r.appendChild(c.cloneNode(!0)),this.selectpicker.view.widestOption&&n.appendChild(this.selectpicker.view.widestOption.cloneNode(!0)),n.appendChild(l),n.appendChild(o),n.appendChild(r),d&&i.appendChild(d),h){var m=document.createElement("input");h.className="bs-searchbox",m.className="form-control",h.appendChild(m),i.appendChild(h)}p&&i.appendChild(p),s.appendChild(n),i.appendChild(s),u&&i.appendChild(u),t.appendChild(i),document.body.appendChild(t);var v,g=l.offsetHeight,b=r?r.offsetHeight:0,w=d?d.offsetHeight:0,I=h?h.offsetHeight:0,x=p?p.offsetHeight:0,k=u?u.offsetHeight:0,$=z(o).outerHeight(!0),y=!!window.getComputedStyle&&window.getComputedStyle(i),S=i.offsetWidth,E=y?null:z(i),C={vert:A(y?y.paddingTop:E.css("paddingTop"))+A(y?y.paddingBottom:E.css("paddingBottom"))+A(y?y.borderTopWidth:E.css("borderTopWidth"))+A(y?y.borderBottomWidth:E.css("borderBottomWidth")),horiz:A(y?y.paddingLeft:E.css("paddingLeft"))+A(y?y.paddingRight:E.css("paddingRight"))+A(y?y.borderLeftWidth:E.css("borderLeftWidth"))+A(y?y.borderRightWidth:E.css("borderRightWidth"))},O={vert:C.vert+A(y?y.marginTop:E.css("marginTop"))+A(y?y.marginBottom:E.css("marginBottom"))+2,horiz:C.horiz+A(y?y.marginLeft:E.css("marginLeft"))+A(y?y.marginRight:E.css("marginRight"))+2};s.style.overflowY="scroll",v=i.offsetWidth-S,document.body.removeChild(t),this.sizeInfo.liHeight=g,this.sizeInfo.dropdownHeaderHeight=b,this.sizeInfo.headerHeight=w,this.sizeInfo.searchHeight=I,this.sizeInfo.actionsHeight=x,this.sizeInfo.doneButtonHeight=k,this.sizeInfo.dividerHeight=$,this.sizeInfo.menuPadding=C,this.sizeInfo.menuExtras=O,this.sizeInfo.menuWidth=S,this.sizeInfo.totalMenuWidth=this.sizeInfo.menuWidth,this.sizeInfo.scrollBarWidth=v,this.sizeInfo.selectHeight=this.$newElement[0].offsetHeight,this.setPositionData()}},getSelectPosition:function(){var e,t=z(window),i=this.$newElement.offset(),s=z(this.options.container);this.options.container&&s.length&&!s.is("body")?((e=s.offset()).top+=parseInt(s.css("borderTopWidth")),e.left+=parseInt(s.css("borderLeftWidth"))):e={top:0,left:0};var n=this.options.windowPadding;this.sizeInfo.selectOffsetTop=i.top-e.top-t.scrollTop(),this.sizeInfo.selectOffsetBot=t.height()-this.sizeInfo.selectOffsetTop-this.sizeInfo.selectHeight-e.top-n[2],this.sizeInfo.selectOffsetLeft=i.left-e.left-t.scrollLeft(),this.sizeInfo.selectOffsetRight=t.width()-this.sizeInfo.selectOffsetLeft-this.sizeInfo.selectWidth-e.left-n[1],this.sizeInfo.selectOffsetTop-=n[0],this.sizeInfo.selectOffsetLeft-=n[3]},setMenuSize:function(e){this.getSelectPosition();var t,i,s,n,o,r,l,a=this.sizeInfo.selectWidth,c=this.sizeInfo.liHeight,d=this.sizeInfo.headerHeight,h=this.sizeInfo.searchHeight,p=this.sizeInfo.actionsHeight,u=this.sizeInfo.doneButtonHeight,f=this.sizeInfo.dividerHeight,m=this.sizeInfo.menuPadding,v=0;if(this.options.dropupAuto&&(l=c*this.selectpicker.current.elements.length+m.vert,this.$newElement.toggleClass(j.DROPUP,this.sizeInfo.selectOffsetTop-this.sizeInfo.selectOffsetBot>this.sizeInfo.menuExtras.vert&&l+this.sizeInfo.menuExtras.vert+50>this.sizeInfo.selectOffsetBot)),"auto"===this.options.size)n=3<this.selectpicker.current.elements.length?3*this.sizeInfo.liHeight+this.sizeInfo.menuExtras.vert-2:0,i=this.sizeInfo.selectOffsetBot-this.sizeInfo.menuExtras.vert,s=n+d+h+p+u,r=Math.max(n-m.vert,0),this.$newElement.hasClass(j.DROPUP)&&(i=this.sizeInfo.selectOffsetTop-this.sizeInfo.menuExtras.vert),t=(o=i)-d-h-p-u-m.vert;else if(this.options.size&&"auto"!=this.options.size&&this.selectpicker.current.elements.length>this.options.size){for(var g=0;g<this.options.size;g++)"divider"===this.selectpicker.current.data[g].type&&v++;t=(i=c*this.options.size+v*f+m.vert)-m.vert,o=i+d+h+p+u,s=r=""}"auto"===this.options.dropdownAlignRight&&this.$menu.toggleClass(j.MENURIGHT,this.sizeInfo.selectOffsetLeft>this.sizeInfo.selectOffsetRight&&this.sizeInfo.selectOffsetRight<this.sizeInfo.totalMenuWidth-a),this.$menu.css({"max-height":o+"px",overflow:"hidden","min-height":s+"px"}),this.$menuInner.css({"max-height":t+"px","overflow-y":"auto","min-height":r+"px"}),this.sizeInfo.menuInnerHeight=Math.max(t,1),this.selectpicker.current.data.length&&this.selectpicker.current.data[this.selectpicker.current.data.length-1].position>this.sizeInfo.menuInnerHeight&&(this.sizeInfo.hasScrollBar=!0,this.sizeInfo.totalMenuWidth=this.sizeInfo.menuWidth+this.sizeInfo.scrollBarWidth,this.$menu.css("min-width",this.sizeInfo.totalMenuWidth)),this.dropdown&&this.dropdown._popper&&this.dropdown._popper.update()},setSize:function(e){if(this.liHeight(e),this.options.header&&this.$menu.css("padding-top",0),!1!==this.options.size){var t=this,i=z(window);this.setMenuSize(),this.options.liveSearch&&this.$searchbox.off("input.setMenuSize propertychange.setMenuSize").on("input.setMenuSize propertychange.setMenuSize",function(){return t.setMenuSize()}),"auto"===this.options.size?i.off("resize"+U+"."+this.selectId+".setMenuSize scroll"+U+"."+this.selectId+".setMenuSize").on("resize"+U+"."+this.selectId+".setMenuSize scroll"+U+"."+this.selectId+".setMenuSize",function(){return t.setMenuSize()}):this.options.size&&"auto"!=this.options.size&&this.selectpicker.current.elements.length>this.options.size&&i.off("resize"+U+"."+this.selectId+".setMenuSize scroll"+U+"."+this.selectId+".setMenuSize"),t.createView(!1,!0,e)}},setWidth:function(){var i=this;"auto"===this.options.width?requestAnimationFrame(function(){i.$menu.css("min-width","0"),i.$element.on("loaded"+U,function(){i.liHeight(),i.setMenuSize();var e=i.$newElement.clone().appendTo("body"),t=e.css("width","auto").children("button").outerWidth();e.remove(),i.sizeInfo.selectWidth=Math.max(i.sizeInfo.totalMenuWidth,t),i.$newElement.css("width",i.sizeInfo.selectWidth+"px")})}):"fit"===this.options.width?(this.$menu.css("min-width",""),this.$newElement.css("width","").addClass("fit-width")):this.options.width?(this.$menu.css("min-width",""),this.$newElement.css("width",this.options.width)):(this.$menu.css("min-width",""),this.$newElement.css("width","")),this.$newElement.hasClass("fit-width")&&"fit"!==this.options.width&&this.$newElement[0].classList.remove("fit-width")},selectPosition:function(){this.$bsContainer=z('<div class="bs-container" />');var s,n,o,r=this,l=z(this.options.container),e=function(e){var t={},i=r.options.display||!!z.fn.dropdown.Constructor.Default&&z.fn.dropdown.Constructor.Default.display;r.$bsContainer.addClass(e.attr("class").replace(/form-control|fit-width/gi,"")).toggleClass(j.DROPUP,e.hasClass(j.DROPUP)),s=e.offset(),l.is("body")?n={top:0,left:0}:((n=l.offset()).top+=parseInt(l.css("borderTopWidth"))-l.scrollTop(),n.left+=parseInt(l.css("borderLeftWidth"))-l.scrollLeft()),o=e.hasClass(j.DROPUP)?0:e[0].offsetHeight,(M.major<4||"static"===i)&&(t.top=s.top-n.top+o,t.left=s.left-n.left),t.width=e[0].offsetWidth,r.$bsContainer.css(t)};this.$button.on("click.bs.dropdown.data-api",function(){r.isDisabled()||(e(r.$newElement),r.$bsContainer.appendTo(r.options.container).toggleClass(j.SHOW,!r.$button.hasClass(j.SHOW)).append(r.$menu))}),z(window).off("resize"+U+"."+this.selectId+" scroll"+U+"."+this.selectId).on("resize"+U+"."+this.selectId+" scroll"+U+"."+this.selectId,function(){r.$newElement.hasClass(j.SHOW)&&e(r.$newElement)}),this.$element.on("hide"+U,function(){r.$menu.data("height",r.$menu.height()),r.$bsContainer.detach()})},setOptionStatus:function(e){var t=this;if(t.noScroll=!1,t.selectpicker.view.visibleElements&&t.selectpicker.view.visibleElements.length)for(var i=0;i<t.selectpicker.view.visibleElements.length;i++){var s=t.selectpicker.current.data[i+t.selectpicker.view.position0],n=s.option;n&&(!0!==e&&t.setDisabled(s.index,s.disabled),t.setSelected(s.index,n.selected))}},setSelected:function(e,t){var i,s,n=this.selectpicker.main.elements[e],o=this.selectpicker.main.data[e],r=void 0!==this.activeIndex,l=this.activeIndex===e||t&&!this.multiple&&!r;o.selected=t,s=n.firstChild,t&&(this.selectedIndex=e),n.classList.toggle("selected",t),l?(this.focusItem(n,o),this.selectpicker.view.currentActive=n,this.activeIndex=e):this.defocusItem(n),s&&(s.classList.toggle("selected",t),t?s.setAttribute("aria-selected",!0):this.multiple?s.setAttribute("aria-selected",!1):s.removeAttribute("aria-selected")),l||r||!t||void 0===this.prevActiveIndex||(i=this.selectpicker.main.elements[this.prevActiveIndex],this.defocusItem(i))},setDisabled:function(e,t){var i,s=this.selectpicker.main.elements[e];this.selectpicker.main.data[e].disabled=t,i=s.firstChild,s.classList.toggle(j.DISABLED,t),i&&("4"===M.major&&i.classList.toggle(j.DISABLED,t),t?(i.setAttribute("aria-disabled",t),i.setAttribute("tabindex",-1)):(i.removeAttribute("aria-disabled"),i.setAttribute("tabindex",0)))},isDisabled:function(){return this.$element[0].disabled},checkDisabled:function(){var e=this;this.isDisabled()?(this.$newElement[0].classList.add(j.DISABLED),this.$button.addClass(j.DISABLED).attr("tabindex",-1).attr("aria-disabled",!0)):(this.$button[0].classList.contains(j.DISABLED)&&(this.$newElement[0].classList.remove(j.DISABLED),this.$button.removeClass(j.DISABLED).attr("aria-disabled",!1)),-1!=this.$button.attr("tabindex")||this.$element.data("tabindex")||this.$button.removeAttr("tabindex")),this.$button.on("click",function(){return!e.isDisabled()})},tabIndex:function(){this.$element.data("tabindex")!==this.$element.attr("tabindex")&&-98!==this.$element.attr("tabindex")&&"-98"!==this.$element.attr("tabindex")&&(this.$element.data("tabindex",this.$element.attr("tabindex")),this.$button.attr("tabindex",this.$element.data("tabindex"))),this.$element.attr("tabindex",-98)},clickListener:function(){var C=this,t=z(document);function e(){C.options.liveSearch?C.$searchbox.trigger("focus"):C.$menuInner.trigger("focus")}function i(){C.dropdown&&C.dropdown._popper&&C.dropdown._popper.state.isCreated?e():requestAnimationFrame(i)}t.data("spaceSelect",!1),this.$button.on("keyup",function(e){/(32)/.test(e.keyCode.toString(10))&&t.data("spaceSelect")&&(e.preventDefault(),t.data("spaceSelect",!1))}),this.$newElement.on("show.bs.dropdown",function(){3<M.major&&!C.dropdown&&(C.dropdown=C.$button.data("bs.dropdown"),C.dropdown._menu=C.$menu[0])}),this.$button.on("click.bs.dropdown.data-api",function(){C.$newElement.hasClass(j.SHOW)||C.setSize()}),this.$element.on("shown"+U,function(){C.$menuInner[0].scrollTop!==C.selectpicker.view.scrollTop&&(C.$menuInner[0].scrollTop=C.selectpicker.view.scrollTop),3<M.major?requestAnimationFrame(i):e()}),this.$menuInner.on("mouseenter","li a",function(e){var t=this.parentElement,i=C.isVirtual()?C.selectpicker.view.position0:0,s=Array.prototype.indexOf.call(t.parentElement.children,t),n=C.selectpicker.current.data[s+i];C.focusItem(t,n,!0)}),this.$menuInner.on("click","li a",function(e,t){var i=z(this),s=C.$element[0],n=C.isVirtual()?C.selectpicker.view.position0:0,o=C.selectpicker.current.data[i.parent().index()+n],r=o.index,l=O(s),a=s.selectedIndex,c=s.options[a],d=!0;if(C.multiple&&1!==C.options.maxOptions&&e.stopPropagation(),e.preventDefault(),!C.isDisabled()&&!i.parent().hasClass(j.DISABLED)){var h=C.$element.find("option"),p=o.option,u=z(p),f=p.selected,m=u.parent("optgroup"),v=m.find("option"),g=C.options.maxOptions,b=m.data("maxOptions")||!1;if(r===C.activeIndex&&(t=!0),t||(C.prevActiveIndex=C.activeIndex,C.activeIndex=void 0),C.multiple){if(p.selected=!f,C.setSelected(r,!f),i.trigger("blur"),!1!==g||!1!==b){var w=g<h.filter(":selected").length,I=b<m.find("option:selected").length;if(g&&w||b&&I)if(g&&1==g){h.prop("selected",!1),u.prop("selected",!0);for(var x=0;x<h.length;x++)C.setSelected(x,!1);C.setSelected(r,!0)}else if(b&&1==b){m.find("option:selected").prop("selected",!1),u.prop("selected",!0);for(x=0;x<v.length;x++){p=v[x];C.setSelected(h.index(p),!1)}C.setSelected(r,!0)}else{var k="string"==typeof C.options.maxOptionsText?[C.options.maxOptionsText,C.options.maxOptionsText]:C.options.maxOptionsText,$="function"==typeof k?k(g,b):k,y=$[0].replace("{n}",g),S=$[1].replace("{n}",b),E=z('<div class="notify"></div>');$[2]&&(y=y.replace("{var}",$[2][1<g?0:1]),S=S.replace("{var}",$[2][1<b?0:1])),u.prop("selected",!1),C.$menu.append(E),g&&w&&(E.append(z("<div>"+y+"</div>")),d=!1,C.$element.trigger("maxReached"+U)),b&&I&&(E.append(z("<div>"+S+"</div>")),d=!1,C.$element.trigger("maxReachedGrp"+U)),setTimeout(function(){C.setSelected(r,!1)},10),E.delay(750).fadeOut(300,function(){z(this).remove()})}}}else c.selected=!1,p.selected=!0,C.setSelected(r,!0);!C.multiple||C.multiple&&1===C.options.maxOptions?C.$button.trigger("focus"):C.options.liveSearch&&C.$searchbox.trigger("focus"),d&&(C.multiple||a!==s.selectedIndex)&&(T=[p.index,u.prop("selected"),l],C.$element.triggerNative("change"))}}),this.$menu.on("click","li."+j.DISABLED+" a, ."+j.POPOVERHEADER+", ."+j.POPOVERHEADER+" :not(.close)",function(e){e.currentTarget==this&&(e.preventDefault(),e.stopPropagation(),C.options.liveSearch&&!z(e.target).hasClass("close")?C.$searchbox.trigger("focus"):C.$button.trigger("focus"))}),this.$menuInner.on("click",".divider, .dropdown-header",function(e){e.preventDefault(),e.stopPropagation(),C.options.liveSearch?C.$searchbox.trigger("focus"):C.$button.trigger("focus")}),this.$menu.on("click","."+j.POPOVERHEADER+" .close",function(){C.$button.trigger("click")}),this.$searchbox.on("click",function(e){e.stopPropagation()}),this.$menu.on("click",".actions-btn",function(e){C.options.liveSearch?C.$searchbox.trigger("focus"):C.$button.trigger("focus"),e.preventDefault(),e.stopPropagation(),z(this).hasClass("bs-select-all")?C.selectAll():C.deselectAll()}),this.$element.on("change"+U,function(){C.render(),C.$element.trigger("changed"+U,T),T=null}).on("focus"+U,function(){C.options.mobile||C.$button.trigger("focus")})},liveSearchListener:function(){var u=this,f=document.createElement("li");this.$button.on("click.bs.dropdown.data-api",function(){u.$searchbox.val()&&u.$searchbox.val("")}),this.$searchbox.on("click.bs.dropdown.data-api focus.bs.dropdown.data-api touchend.bs.dropdown.data-api",function(e){e.stopPropagation()}),this.$searchbox.on("input propertychange",function(){var e=u.$searchbox.val();if(u.selectpicker.search.elements=[],u.selectpicker.search.data=[],e){var t=[],i=e.toUpperCase(),s={},n=[],o=u._searchStyle(),r=u.options.liveSearchNormalize;r&&(i=w(i)),u._$lisSelected=u.$menuInner.find(".selected");for(var l=0;l<u.selectpicker.main.data.length;l++){var a=u.selectpicker.main.data[l];s[l]||(s[l]=k(a,i,o,r)),s[l]&&void 0!==a.headerIndex&&-1===n.indexOf(a.headerIndex)&&(0<a.headerIndex&&(s[a.headerIndex-1]=!0,n.push(a.headerIndex-1)),s[a.headerIndex]=!0,n.push(a.headerIndex),s[a.lastIndex+1]=!0),s[l]&&"optgroup-label"!==a.type&&n.push(l)}l=0;for(var c=n.length;l<c;l++){var d=n[l],h=n[l-1],p=(a=u.selectpicker.main.data[d],u.selectpicker.main.data[h]);("divider"!==a.type||"divider"===a.type&&p&&"divider"!==p.type&&c-1!==l)&&(u.selectpicker.search.data.push(a),t.push(u.selectpicker.main.elements[d]))}u.activeIndex=void 0,u.noScroll=!0,u.$menuInner.scrollTop(0),u.selectpicker.search.elements=t,u.createView(!0),t.length||(f.className="no-results",f.innerHTML=u.options.noneResultsText.replace("{0}",'"'+E(e)+'"'),u.$menuInner[0].firstChild.appendChild(f))}else u.$menuInner.scrollTop(0),u.createView(!1)})},_searchStyle:function(){return this.options.liveSearchStyle||"contains"},val:function(e){var t=this.$element[0];if(void 0===e)return this.$element.val();var i=O(t);if(T=[null,null,i],this.$element.val(e).trigger("changed"+U,T),this.$newElement.hasClass(j.SHOW))if(this.multiple)this.setOptionStatus(!0);else{var s=(t.options[t.selectedIndex]||{}).liIndex;"number"==typeof s&&(this.setSelected(this.selectedIndex,!1),this.setSelected(s,!0))}return this.render(),T=null,this.$element},changeAll:function(e){if(this.multiple){void 0===e&&(e=!0);var t=this.$element[0],i=0,s=0,n=O(t);t.classList.add("bs-select-hidden");for(var o=0,r=this.selectpicker.current.elements.length;o<r;o++){var l=this.selectpicker.current.data[o],a=l.option;a&&!l.disabled&&"divider"!==l.type&&(l.selected&&i++,(a.selected=e)&&s++)}t.classList.remove("bs-select-hidden"),i!==s&&(this.setOptionStatus(),T=[null,null,n],this.$element.triggerNative("change"))}},selectAll:function(){return this.changeAll(!0)},deselectAll:function(){return this.changeAll(!1)},toggle:function(e){(e=e||window.event)&&e.stopPropagation(),this.$button.trigger("click.bs.dropdown.data-api")},keydown:function(e){var t,i,s,n,o,r=z(this),l=r.hasClass("dropdown-toggle"),a=(l?r.closest(".dropdown"):r.closest(V.MENU)).data("this"),c=a.findLis(),d=!1,h=e.which===H&&!l&&!a.options.selectOnTab,p=_.test(e.which)||h,u=a.$menuInner[0].scrollTop,f=!0===a.isVirtual()?a.selectpicker.view.position0:0;if(!(i=a.$newElement.hasClass(j.SHOW))&&(p||48<=e.which&&e.which<=57||96<=e.which&&e.which<=105||65<=e.which&&e.which<=90)&&(a.$button.trigger("click.bs.dropdown.data-api"),a.options.liveSearch))a.$searchbox.trigger("focus");else{if(e.which===L&&i&&(e.preventDefault(),a.$button.trigger("click.bs.dropdown.data-api").trigger("focus")),p){if(!c.length)return;-1!==(t=(s=a.selectpicker.main.elements[a.activeIndex])?Array.prototype.indexOf.call(s.parentElement.children,s):-1)&&a.defocusItem(s),e.which===B?(-1!==t&&t--,t+f<0&&(t+=c.length),a.selectpicker.view.canHighlight[t+f]||-1===(t=a.selectpicker.view.canHighlight.slice(0,t+f).lastIndexOf(!0)-f)&&(t=c.length-1)):(e.which===W||h)&&(++t+f>=a.selectpicker.view.canHighlight.length&&(t=0),a.selectpicker.view.canHighlight[t+f]||(t=t+1+a.selectpicker.view.canHighlight.slice(t+f+1).indexOf(!0))),e.preventDefault();var m=f+t;e.which===B?0===f&&t===c.length-1?(a.$menuInner[0].scrollTop=a.$menuInner[0].scrollHeight,m=a.selectpicker.current.elements.length-1):d=(o=(n=a.selectpicker.current.data[m]).position-n.height)<u:(e.which===W||h)&&(0===t?m=a.$menuInner[0].scrollTop=0:d=u<(o=(n=a.selectpicker.current.data[m]).position-a.sizeInfo.menuInnerHeight)),s=a.selectpicker.current.elements[m],a.activeIndex=a.selectpicker.current.data[m].index,a.focusItem(s),a.selectpicker.view.currentActive=s,d&&(a.$menuInner[0].scrollTop=o),a.options.liveSearch?a.$searchbox.trigger("focus"):r.trigger("focus")}else if(!r.is("input")&&!G.test(e.which)||e.which===D&&a.selectpicker.keydown.keyHistory){var v,g,b=[];e.preventDefault(),a.selectpicker.keydown.keyHistory+=C[e.which],a.selectpicker.keydown.resetKeyHistory.cancel&&clearTimeout(a.selectpicker.keydown.resetKeyHistory.cancel),a.selectpicker.keydown.resetKeyHistory.cancel=a.selectpicker.keydown.resetKeyHistory.start(),g=a.selectpicker.keydown.keyHistory,/^(.)\1+$/.test(g)&&(g=g.charAt(0));for(var w=0;w<a.selectpicker.current.data.length;w++){var I=a.selectpicker.current.data[w];k(I,g,"startsWith",!0)&&a.selectpicker.view.canHighlight[w]&&b.push(I.index)}if(b.length){var x=0;c.removeClass("active").find("a").removeClass("active"),1===g.length&&(-1===(x=b.indexOf(a.activeIndex))||x===b.length-1?x=0:x++),v=b[x],d=0<u-(n=a.selectpicker.main.data[v]).position?(o=n.position-n.height,!0):(o=n.position-a.sizeInfo.menuInnerHeight,n.position>u+a.sizeInfo.menuInnerHeight),s=a.selectpicker.main.elements[v],a.activeIndex=b[x],a.focusItem(s),s&&s.firstChild.focus(),d&&(a.$menuInner[0].scrollTop=o),r.trigger("focus")}}i&&(e.which===D&&!a.selectpicker.keydown.keyHistory||e.which===N||e.which===H&&a.options.selectOnTab)&&(e.which!==D&&e.preventDefault(),a.options.liveSearch&&e.which===D||(a.$menuInner.find(".active a").trigger("click",!0),r.trigger("focus"),a.options.liveSearch||(e.preventDefault(),z(document).data("spaceSelect",!0))))}},mobile:function(){this.$element[0].classList.add("mobile-device")},refresh:function(){var e=z.extend({},this.options,this.$element.data());this.options=e,this.checkDisabled(),this.setStyle(),this.render(),this.createLi(),this.setWidth(),this.setSize(!0),this.$element.trigger("refreshed"+U)},hide:function(){this.$newElement.hide()},show:function(){this.$newElement.show()},remove:function(){this.$newElement.remove(),this.$element.remove()},destroy:function(){this.$newElement.before(this.$element).remove(),this.$bsContainer?this.$bsContainer.remove():this.$menu.remove(),this.$element.off(U).removeData("selectpicker").removeClass("bs-select-hidden selectpicker"),z(window).off(U+"."+this.selectId)}};var X=z.fn.selectpicker;z.fn.selectpicker=Q,z.fn.selectpicker.Constructor=J,z.fn.selectpicker.noConflict=function(){return z.fn.selectpicker=X,this},z(document).off("keydown.bs.dropdown.data-api").on("keydown"+U,'.bootstrap-select [data-toggle="dropdown"], .bootstrap-select [role="listbox"], .bootstrap-select .bs-searchbox input',J.prototype.keydown).on("focusin.modal",'.bootstrap-select [data-toggle="dropdown"], .bootstrap-select [role="listbox"], .bootstrap-select .bs-searchbox input',function(e){e.stopPropagation()}),z(window).on("load"+U+".data-api",function(){z(".selectpicker").each(function(){var e=z(this);Q.call(e,e.data())})})}(e)});
+! function(e, t) {
+    void 0 === e && void 0 !== window && (e = window), "function" == typeof define && define.amd ? define(["jquery"], function(e) {
+        return t(e)
+    }) : "object" == typeof module && module.exports ? module.exports = t(require("jquery")) : t(e.jQuery)
+}(this, function(e) {
+    ! function(z) {
+        "use strict";
+        var d = ["sanitize", "whiteList", "sanitizeFn"],
+            r = ["background", "cite", "href", "itemtype", "longdesc", "poster", "src", "xlink:href"],
+            e = {
+                "*": ["class", "dir", "id", "lang", "role", "tabindex", "style", /^aria-[\w-]*$/i],
+                a: ["target", "href", "title", "rel"],
+                area: [],
+                b: [],
+                br: [],
+                col: [],
+                code: [],
+                div: [],
+                em: [],
+                hr: [],
+                h1: [],
+                h2: [],
+                h3: [],
+                h4: [],
+                h5: [],
+                h6: [],
+                i: [],
+                img: ["src", "alt", "title", "width", "height"],
+                li: [],
+                ol: [],
+                p: [],
+                pre: [],
+                s: [],
+                small: [],
+                span: [],
+                sub: [],
+                sup: [],
+                strong: [],
+                u: [],
+                ul: []
+            },
+            l = /^(?:(?:https?|mailto|ftp|tel|file):|[^&:/?#]*(?:[/?#]|$))/gi,
+            a = /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+/]+=*$/i;
+
+        function v(e, t) {
+            var i = e.nodeName.toLowerCase();
+            if (-1 !== z.inArray(i, t)) return -1 === z.inArray(i, r) || Boolean(e.nodeValue.match(l) || e.nodeValue.match(a));
+            for (var s = z(t).filter(function(e, t) {
+                    return t instanceof RegExp
+                }), n = 0, o = s.length; n < o; n++)
+                if (i.match(s[n])) return !0;
+            return !1
+        }
+
+        function P(e, t, i) {
+            if (i && "function" == typeof i) return i(e);
+            for (var s = Object.keys(t), n = 0, o = e.length; n < o; n++)
+                for (var r = e[n].querySelectorAll("*"), l = 0, a = r.length; l < a; l++) {
+                    var c = r[l],
+                        d = c.nodeName.toLowerCase();
+                    if (-1 !== s.indexOf(d))
+                        for (var h = [].slice.call(c.attributes), p = [].concat(t["*"] || [], t[d] || []), u = 0, f = h.length; u < f; u++) {
+                            var m = h[u];
+                            v(m, p) || c.removeAttribute(m.nodeName)
+                        } else c.parentNode.removeChild(c)
+                }
+        }
+        "classList" in document.createElement("_") || function(e) {
+            if ("Element" in e) {
+                var t = "classList",
+                    i = "prototype",
+                    s = e.Element[i],
+                    n = Object,
+                    o = function() {
+                        var i = z(this);
+                        return {
+                            add: function(e) {
+                                return e = Array.prototype.slice.call(arguments).join(" "), i.addClass(e)
+                            },
+                            remove: function(e) {
+                                return e = Array.prototype.slice.call(arguments).join(" "), i.removeClass(e)
+                            },
+                            toggle: function(e, t) {
+                                return i.toggleClass(e, t)
+                            },
+                            contains: function(e) {
+                                return i.hasClass(e)
+                            }
+                        }
+                    };
+                if (n.defineProperty) {
+                    var r = {
+                        get: o,
+                        enumerable: !0,
+                        configurable: !0
+                    };
+                    try {
+                        n.defineProperty(s, t, r)
+                    } catch (e) {
+                        void 0 !== e.number && -2146823252 !== e.number || (r.enumerable = !1, n.defineProperty(s, t, r))
+                    }
+                } else n[i].__defineGetter__ && s.__defineGetter__(t, o)
+            }
+        }(window);
+        var t, c, i, s = document.createElement("_");
+        if (s.classList.add("c1", "c2"), !s.classList.contains("c2")) {
+            var n = DOMTokenList.prototype.add,
+                o = DOMTokenList.prototype.remove;
+            DOMTokenList.prototype.add = function() {
+                Array.prototype.forEach.call(arguments, n.bind(this))
+            }, DOMTokenList.prototype.remove = function() {
+                Array.prototype.forEach.call(arguments, o.bind(this))
+            }
+        }
+        if (s.classList.toggle("c3", !1), s.classList.contains("c3")) {
+            var h = DOMTokenList.prototype.toggle;
+            DOMTokenList.prototype.toggle = function(e, t) {
+                return 1 in arguments && !this.contains(e) == !t ? t : h.call(this, e)
+            }
+        }
+
+        function O(e, t) {
+            for (var i, s = [], n = t || e.selectedOptions, o = 0, r = n.length; o < r; o++)(i = n[o]).disabled || "OPTGROUP" === i.parentNode.tagName && i.parentNode.disabled || s.push(i.value || i.text);
+            return e.multiple ? s : s.length ? s[0] : null
+        }
+        s = null, String.prototype.startsWith || (t = function() {
+            try {
+                var e = {},
+                    t = Object.defineProperty,
+                    i = t(e, e, e) && t
+            } catch (e) {}
+            return i
+        }(), c = {}.toString, i = function(e) {
+            if (null == this) throw new TypeError;
+            var t = String(this);
+            if (e && "[object RegExp]" == c.call(e)) throw new TypeError;
+            var i = t.length,
+                s = String(e),
+                n = s.length,
+                o = 1 < arguments.length ? arguments[1] : void 0,
+                r = o ? Number(o) : 0;
+            r != r && (r = 0);
+            var l = Math.min(Math.max(r, 0), i);
+            if (i < n + l) return !1;
+            for (var a = -1; ++a < n;)
+                if (t.charCodeAt(l + a) != s.charCodeAt(a)) return !1;
+            return !0
+        }, t ? t(String.prototype, "startsWith", {
+            value: i,
+            configurable: !0,
+            writable: !0
+        }) : String.prototype.startsWith = i), Object.keys || (Object.keys = function(e, t, i) {
+            for (t in i = [], e) i.hasOwnProperty.call(e, t) && i.push(t);
+            return i
+        }), HTMLSelectElement && !HTMLSelectElement.prototype.hasOwnProperty("selectedOptions") && Object.defineProperty(HTMLSelectElement.prototype, "selectedOptions", {
+            get: function() {
+                return this.querySelectorAll(":checked")
+            }
+        });
+        var p = {
+            useDefault: !1,
+            _set: z.valHooks.select.set
+        };
+        z.valHooks.select.set = function(e, t) {
+            return t && !p.useDefault && z(e).data("selected", !0), p._set.apply(this, arguments)
+        };
+        var T = null,
+            u = function() {
+                try {
+                    return new Event("change"), !0
+                } catch (e) {
+                    return !1
+                }
+            }();
+
+        function k(e, t, i, s) {
+            for (var n = ["display", "subtext", "tokens"], o = !1, r = 0; r < n.length; r++) {
+                var l = n[r],
+                    a = e[l];
+                if (a && (a = a.toString(), "display" === l && (a = a.replace(/<[^>]+>/g, "")), s && (a = w(a)), a = a.toUpperCase(), o = "contains" === i ? 0 <= a.indexOf(t) : a.startsWith(t))) break
+            }
+            return o
+        }
+
+        function A(e) {
+            return parseInt(e, 10) || 0
+        }
+        z.fn.triggerNative = function(e) {
+            var t, i = this[0];
+            i.dispatchEvent ? (u ? t = new Event(e, {
+                bubbles: !0
+            }) : (t = document.createEvent("Event")).initEvent(e, !0, !1), i.dispatchEvent(t)) : i.fireEvent ? ((t = document.createEventObject()).eventType = e, i.fireEvent("on" + e, t)) : this.trigger(e)
+        };
+        var f = {
+                "\xc0": "A",
+                "\xc1": "A",
+                "\xc2": "A",
+                "\xc3": "A",
+                "\xc4": "A",
+                "\xc5": "A",
+                "\xe0": "a",
+                "\xe1": "a",
+                "\xe2": "a",
+                "\xe3": "a",
+                "\xe4": "a",
+                "\xe5": "a",
+                "\xc7": "C",
+                "\xe7": "c",
+                "\xd0": "D",
+                "\xf0": "d",
+                "\xc8": "E",
+                "\xc9": "E",
+                "\xca": "E",
+                "\xcb": "E",
+                "\xe8": "e",
+                "\xe9": "e",
+                "\xea": "e",
+                "\xeb": "e",
+                "\xcc": "I",
+                "\xcd": "I",
+                "\xce": "I",
+                "\xcf": "I",
+                "\xec": "i",
+                "\xed": "i",
+                "\xee": "i",
+                "\xef": "i",
+                "\xd1": "N",
+                "\xf1": "n",
+                "\xd2": "O",
+                "\xd3": "O",
+                "\xd4": "O",
+                "\xd5": "O",
+                "\xd6": "O",
+                "\xd8": "O",
+                "\xf2": "o",
+                "\xf3": "o",
+                "\xf4": "o",
+                "\xf5": "o",
+                "\xf6": "o",
+                "\xf8": "o",
+                "\xd9": "U",
+                "\xda": "U",
+                "\xdb": "U",
+                "\xdc": "U",
+                "\xf9": "u",
+                "\xfa": "u",
+                "\xfb": "u",
+                "\xfc": "u",
+                "\xdd": "Y",
+                "\xfd": "y",
+                "\xff": "y",
+                "\xc6": "Ae",
+                "\xe6": "ae",
+                "\xde": "Th",
+                "\xfe": "th",
+                "\xdf": "ss",
+                "\u0100": "A",
+                "\u0102": "A",
+                "\u0104": "A",
+                "\u0101": "a",
+                "\u0103": "a",
+                "\u0105": "a",
+                "\u0106": "C",
+                "\u0108": "C",
+                "\u010a": "C",
+                "\u010c": "C",
+                "\u0107": "c",
+                "\u0109": "c",
+                "\u010b": "c",
+                "\u010d": "c",
+                "\u010e": "D",
+                "\u0110": "D",
+                "\u010f": "d",
+                "\u0111": "d",
+                "\u0112": "E",
+                "\u0114": "E",
+                "\u0116": "E",
+                "\u0118": "E",
+                "\u011a": "E",
+                "\u0113": "e",
+                "\u0115": "e",
+                "\u0117": "e",
+                "\u0119": "e",
+                "\u011b": "e",
+                "\u011c": "G",
+                "\u011e": "G",
+                "\u0120": "G",
+                "\u0122": "G",
+                "\u011d": "g",
+                "\u011f": "g",
+                "\u0121": "g",
+                "\u0123": "g",
+                "\u0124": "H",
+                "\u0126": "H",
+                "\u0125": "h",
+                "\u0127": "h",
+                "\u0128": "I",
+                "\u012a": "I",
+                "\u012c": "I",
+                "\u012e": "I",
+                "\u0130": "I",
+                "\u0129": "i",
+                "\u012b": "i",
+                "\u012d": "i",
+                "\u012f": "i",
+                "\u0131": "i",
+                "\u0134": "J",
+                "\u0135": "j",
+                "\u0136": "K",
+                "\u0137": "k",
+                "\u0138": "k",
+                "\u0139": "L",
+                "\u013b": "L",
+                "\u013d": "L",
+                "\u013f": "L",
+                "\u0141": "L",
+                "\u013a": "l",
+                "\u013c": "l",
+                "\u013e": "l",
+                "\u0140": "l",
+                "\u0142": "l",
+                "\u0143": "N",
+                "\u0145": "N",
+                "\u0147": "N",
+                "\u014a": "N",
+                "\u0144": "n",
+                "\u0146": "n",
+                "\u0148": "n",
+                "\u014b": "n",
+                "\u014c": "O",
+                "\u014e": "O",
+                "\u0150": "O",
+                "\u014d": "o",
+                "\u014f": "o",
+                "\u0151": "o",
+                "\u0154": "R",
+                "\u0156": "R",
+                "\u0158": "R",
+                "\u0155": "r",
+                "\u0157": "r",
+                "\u0159": "r",
+                "\u015a": "S",
+                "\u015c": "S",
+                "\u015e": "S",
+                "\u0160": "S",
+                "\u015b": "s",
+                "\u015d": "s",
+                "\u015f": "s",
+                "\u0161": "s",
+                "\u0162": "T",
+                "\u0164": "T",
+                "\u0166": "T",
+                "\u0163": "t",
+                "\u0165": "t",
+                "\u0167": "t",
+                "\u0168": "U",
+                "\u016a": "U",
+                "\u016c": "U",
+                "\u016e": "U",
+                "\u0170": "U",
+                "\u0172": "U",
+                "\u0169": "u",
+                "\u016b": "u",
+                "\u016d": "u",
+                "\u016f": "u",
+                "\u0171": "u",
+                "\u0173": "u",
+                "\u0174": "W",
+                "\u0175": "w",
+                "\u0176": "Y",
+                "\u0177": "y",
+                "\u0178": "Y",
+                "\u0179": "Z",
+                "\u017b": "Z",
+                "\u017d": "Z",
+                "\u017a": "z",
+                "\u017c": "z",
+                "\u017e": "z",
+                "\u0132": "IJ",
+                "\u0133": "ij",
+                "\u0152": "Oe",
+                "\u0153": "oe",
+                "\u0149": "'n",
+                "\u017f": "s"
+            },
+            m = /[\xc0-\xd6\xd8-\xf6\xf8-\xff\u0100-\u017f]/g,
+            g = RegExp("[\\u0300-\\u036f\\ufe20-\\ufe2f\\u20d0-\\u20ff\\u1ab0-\\u1aff\\u1dc0-\\u1dff]", "g");
+
+        function b(e) {
+            return f[e]
+        }
+
+        function w(e) {
+            return (e = e.toString()) && e.replace(m, b).replace(g, "")
+        }
+        var I, x, $, y, S, E = (I = {
+                "&": "&amp;",
+                "<": "&lt;",
+                ">": "&gt;",
+                '"': "&quot;",
+                "'": "&#x27;",
+                "`": "&#x60;"
+            }, x = function(e) {
+                return I[e]
+            }, $ = "(?:" + Object.keys(I).join("|") + ")", y = RegExp($), S = RegExp($, "g"), function(e) {
+                return e = null == e ? "" : "" + e, y.test(e) ? e.replace(S, x) : e
+            }),
+            C = {
+                32: " ",
+                48: "0",
+                49: "1",
+                50: "2",
+                51: "3",
+                52: "4",
+                53: "5",
+                54: "6",
+                55: "7",
+                56: "8",
+                57: "9",
+                59: ";",
+                65: "A",
+                66: "B",
+                67: "C",
+                68: "D",
+                69: "E",
+                70: "F",
+                71: "G",
+                72: "H",
+                73: "I",
+                74: "J",
+                75: "K",
+                76: "L",
+                77: "M",
+                78: "N",
+                79: "O",
+                80: "P",
+                81: "Q",
+                82: "R",
+                83: "S",
+                84: "T",
+                85: "U",
+                86: "V",
+                87: "W",
+                88: "X",
+                89: "Y",
+                90: "Z",
+                96: "0",
+                97: "1",
+                98: "2",
+                99: "3",
+                100: "4",
+                101: "5",
+                102: "6",
+                103: "7",
+                104: "8",
+                105: "9"
+            },
+            L = 27,
+            N = 13,
+            D = 32,
+            H = 9,
+            B = 38,
+            W = 40,
+            M = {
+                success: !1,
+                major: "3"
+            };
+        try {
+            M.full = (z.fn.dropdown.Constructor.VERSION || "").split(" ")[0].split("."), M.major = M.full[0], M.success = !0
+        } catch (e) {}
+        var R = 0,
+            U = ".bs.select",
+            j = {
+                DISABLED: "disabled",
+                DIVIDER: "divider",
+                SHOW: "open",
+                DROPUP: "dropup",
+                MENU: "dropdown-menu",
+                MENURIGHT: "dropdown-menu-right",
+                MENULEFT: "dropdown-menu-left",
+                BUTTONCLASS: "btn-default",
+                POPOVERHEADER: "popover-title",
+                ICONBASE: "glyphicon",
+                TICKICON: "glyphicon-ok"
+            },
+            V = {
+                MENU: "." + j.MENU
+            },
+            F = {
+                span: document.createElement("span"),
+                i: document.createElement("i"),
+                subtext: document.createElement("small"),
+                a: document.createElement("a"),
+                li: document.createElement("li"),
+                whitespace: document.createTextNode("\xa0"),
+                fragment: document.createDocumentFragment()
+            };
+        F.a.setAttribute("role", "option"), F.subtext.className = "text-muted", F.text = F.span.cloneNode(!1), F.text.className = "text", F.checkMark = F.span.cloneNode(!1);
+        var _ = new RegExp(B + "|" + W),
+            G = new RegExp("^" + H + "$|" + L),
+            q = function(e, t, i) {
+                var s = F.li.cloneNode(!1);
+                return e && (1 === e.nodeType || 11 === e.nodeType ? s.appendChild(e) : s.innerHTML = e), void 0 !== t && "" !== t && (s.className = t), null != i && s.classList.add("optgroup-" + i), s
+            },
+            K = function(e, t, i) {
+                var s = F.a.cloneNode(!0);
+                return e && (11 === e.nodeType ? s.appendChild(e) : s.insertAdjacentHTML("beforeend", e)), void 0 !== t && "" !== t && (s.className = t), "4" === M.major && s.classList.add("dropdown-item"), i && s.setAttribute("style", i), s
+            },
+            Y = function(e, t) {
+                var i, s, n = F.text.cloneNode(!1);
+                if (e.content) n.innerHTML = e.content;
+                else {
+                    if (n.textContent = e.text, e.icon) {
+                        var o = F.whitespace.cloneNode(!1);
+                        (s = (!0 === t ? F.i : F.span).cloneNode(!1)).className = e.iconBase + " " + e.icon, F.fragment.appendChild(s), F.fragment.appendChild(o)
+                    }
+                    e.subtext && ((i = F.subtext.cloneNode(!1)).textContent = e.subtext, n.appendChild(i))
+                }
+                if (!0 === t)
+                    for (; 0 < n.childNodes.length;) F.fragment.appendChild(n.childNodes[0]);
+                else F.fragment.appendChild(n);
+                return F.fragment
+            },
+            Z = function(e) {
+                var t, i, s = F.text.cloneNode(!1);
+                if (s.innerHTML = e.label, e.icon) {
+                    var n = F.whitespace.cloneNode(!1);
+                    (i = F.span.cloneNode(!1)).className = e.iconBase + " " + e.icon, F.fragment.appendChild(i), F.fragment.appendChild(n)
+                }
+                return e.subtext && ((t = F.subtext.cloneNode(!1)).textContent = e.subtext, s.appendChild(t)), F.fragment.appendChild(s), F.fragment
+            },
+            J = function(e, t) {
+                var i = this;
+                p.useDefault || (z.valHooks.select.set = p._set, p.useDefault = !0), this.$element = z(e), this.$newElement = null, this.$button = null, this.$menu = null, this.options = t, this.selectpicker = {
+                    main: {},
+                    search: {},
+                    current: {},
+                    view: {},
+                    keydown: {
+                        keyHistory: "",
+                        resetKeyHistory: {
+                            start: function() {
+                                return setTimeout(function() {
+                                    i.selectpicker.keydown.keyHistory = ""
+                                }, 800)
+                            }
+                        }
+                    }
+                }, null === this.options.title && (this.options.title = this.$element.attr("title"));
+                var s = this.options.windowPadding;
+                "number" == typeof s && (this.options.windowPadding = [s, s, s, s]), this.val = J.prototype.val, this.render = J.prototype.render, this.refresh = J.prototype.refresh, this.setStyle = J.prototype.setStyle, this.selectAll = J.prototype.selectAll, this.deselectAll = J.prototype.deselectAll, this.destroy = J.prototype.destroy, this.remove = J.prototype.remove, this.show = J.prototype.show, this.hide = J.prototype.hide, this.init()
+            };
+
+        function Q(e) {
+            var l, a = arguments,
+                c = e;
+            if ([].shift.apply(a), !M.success) {
+                try {
+                    M.full = (z.fn.dropdown.Constructor.VERSION || "").split(" ")[0].split(".")
+                } catch (e) {
+                    J.BootstrapVersion ? M.full = J.BootstrapVersion.split(" ")[0].split(".") : (M.full = [M.major, "0", "0"], console.warn("There was an issue retrieving Bootstrap's version. Ensure Bootstrap is being loaded before bootstrap-select and there is no namespace collision. If loading Bootstrap asynchronously, the version may need to be manually specified via $.fn.selectpicker.Constructor.BootstrapVersion.", e))
+                }
+                M.major = M.full[0], M.success = !0
+            }
+            if ("4" === M.major) {
+                var t = [];
+                J.DEFAULTS.style === j.BUTTONCLASS && t.push({
+                    name: "style",
+                    className: "BUTTONCLASS"
+                }), J.DEFAULTS.iconBase === j.ICONBASE && t.push({
+                    name: "iconBase",
+                    className: "ICONBASE"
+                }), J.DEFAULTS.tickIcon === j.TICKICON && t.push({
+                    name: "tickIcon",
+                    className: "TICKICON"
+                }), j.DIVIDER = "dropdown-divider", j.SHOW = "show", j.BUTTONCLASS = "btn-light", j.POPOVERHEADER = "popover-header", j.ICONBASE = "", j.TICKICON = "bs-ok-default";
+                for (var i = 0; i < t.length; i++) {
+                    e = t[i];
+                    J.DEFAULTS[e.name] = j[e.className]
+                }
+            }
+            var s = this.each(function() {
+                var e = z(this);
+                if (e.is("select")) {
+                    var t = e.data("selectpicker"),
+                        i = "object" == typeof c && c;
+                    if (t) {
+                        if (i)
+                            for (var s in i) i.hasOwnProperty(s) && (t.options[s] = i[s])
+                    } else {
+                        var n = e.data();
+                        for (var o in n) n.hasOwnProperty(o) && -1 !== z.inArray(o, d) && delete n[o];
+                        var r = z.extend({}, J.DEFAULTS, z.fn.selectpicker.defaults || {}, n, i);
+                        r.template = z.extend({}, J.DEFAULTS.template, z.fn.selectpicker.defaults ? z.fn.selectpicker.defaults.template : {}, n.template, i.template), e.data("selectpicker", t = new J(this, r))
+                    }
+                    "string" == typeof c && (l = t[c] instanceof Function ? t[c].apply(t, a) : t.options[c])
+                }
+            });
+            return void 0 !== l ? l : s
+        }
+        J.VERSION = "1.13.10", J.DEFAULTS = {
+            noneSelectedText: "Nothing selected",
+            noneResultsText: "No results matched {0}",
+            countSelectedText: function(e, t) {
+                return 1 == e ? "{0} item selected" : "{0} items selected"
+            },
+            maxOptionsText: function(e, t) {
+                return [1 == e ? "Limit reached ({n} item max)" : "Limit reached ({n} items max)", 1 == t ? "Group limit reached ({n} item max)" : "Group limit reached ({n} items max)"]
+            },
+            selectAllText: "Select All",
+            deselectAllText: "Deselect All",
+            doneButton: !1,
+            doneButtonText: "Close",
+            multipleSeparator: ", ",
+            styleBase: "btn",
+            style: j.BUTTONCLASS,
+            size: "auto",
+            title: null,
+            selectedTextFormat: "values",
+            width: !1,
+            container: !1,
+            hideDisabled: !1,
+            showSubtext: !1,
+            showIcon: !0,
+            showContent: !0,
+            dropupAuto: !0,
+            header: !1,
+            liveSearch: !1,
+            liveSearchPlaceholder: null,
+            liveSearchNormalize: !1,
+            liveSearchStyle: "contains",
+            actionsBox: !1,
+            iconBase: j.ICONBASE,
+            tickIcon: j.TICKICON,
+            showTick: !1,
+            template: {
+                caret: '<span class="caret"></span>'
+            },
+            maxOptions: !1,
+            mobile: !1,
+            selectOnTab: !1,
+            dropdownAlignRight: !1,
+            windowPadding: 0,
+            virtualScroll: 600,
+            display: !1,
+            sanitize: !0,
+            sanitizeFn: null,
+            whiteList: e
+        }, J.prototype = {
+            constructor: J,
+            init: function() {
+                var i = this,
+                    e = this.$element.attr("id");
+                R++, this.selectId = "bs-select-" + R, this.$element[0].classList.add("bs-select-hidden"), this.multiple = this.$element.prop("multiple"), this.autofocus = this.$element.prop("autofocus"), this.$element[0].classList.contains("show-tick") && (this.options.showTick = !0), this.$newElement = this.createDropdown(), this.$element.after(this.$newElement).prependTo(this.$newElement), this.$button = this.$newElement.children("button"), this.$menu = this.$newElement.children(V.MENU), this.$menuInner = this.$menu.children(".inner"), this.$searchbox = this.$menu.find("input"), this.$element[0].classList.remove("bs-select-hidden"), !0 === this.options.dropdownAlignRight && this.$menu[0].classList.add(j.MENURIGHT), void 0 !== e && this.$button.attr("data-id", e), this.checkDisabled(), this.clickListener(), this.options.liveSearch ? (this.liveSearchListener(), this.focusedParent = this.$searchbox[0]) : this.focusedParent = this.$menuInner[0], this.setStyle(), this.render(), this.setWidth(), this.options.container ? this.selectPosition() : this.$element.on("hide" + U, function() {
+                    if (i.isVirtual()) {
+                        var e = i.$menuInner[0],
+                            t = e.firstChild.cloneNode(!1);
+                        e.replaceChild(t, e.firstChild), e.scrollTop = 0
+                    }
+                }), this.$menu.data("this", this), this.$newElement.data("this", this), this.options.mobile && this.mobile(), this.$newElement.on({
+                    "hide.bs.dropdown": function(e) {
+                        i.$element.trigger("hide" + U, e)
+                    },
+                    "hidden.bs.dropdown": function(e) {
+                        i.$element.trigger("hidden" + U, e)
+                    },
+                    "show.bs.dropdown": function(e) {
+                        i.$element.trigger("show" + U, e)
+                    },
+                    "shown.bs.dropdown": function(e) {
+                        i.$element.trigger("shown" + U, e)
+                    }
+                }), i.$element[0].hasAttribute("required") && this.$element.on("invalid" + U, function() {
+                    i.$button[0].classList.add("bs-invalid"), i.$element.on("shown" + U + ".invalid", function() {
+                        i.$element.val(i.$element.val()).off("shown" + U + ".invalid")
+                    }).on("rendered" + U, function() {
+                        this.validity.valid && i.$button[0].classList.remove("bs-invalid"), i.$element.off("rendered" + U)
+                    }), i.$button.on("blur" + U, function() {
+                        i.$element.trigger("focus").trigger("blur"), i.$button.off("blur" + U)
+                    })
+                }), setTimeout(function() {
+                    i.createLi(), i.$element.trigger("loaded" + U)
+                })
+            },
+            createDropdown: function() {
+                var e = this.multiple || this.options.showTick ? " show-tick" : "",
+                    t = this.multiple ? ' aria-multiselectable="true"' : "",
+                    i = "",
+                    s = this.autofocus ? " autofocus" : "";
+                M.major < 4 && this.$element.parent().hasClass("input-group") && (i = " input-group-btn");
+                var n, o = "",
+                    r = "",
+                    l = "",
+                    a = "";
+                return this.options.header && (o = '<div class="' + j.POPOVERHEADER + '"><button type="button" class="close" aria-hidden="true">&times;</button>' + this.options.header + "</div>"), this.options.liveSearch && (r = '<div class="bs-searchbox"><input type="text" class="form-control" autocomplete="off"' + (null === this.options.liveSearchPlaceholder ? "" : ' placeholder="' + E(this.options.liveSearchPlaceholder) + '"') + ' role="combobox" aria-label="Search" aria-controls="' + this.selectId + '" aria-autocomplete="list"></div>'), this.multiple && this.options.actionsBox && (l = '<div class="bs-actionsbox"><div class="btn-group btn-group-sm btn-block"><button type="button" class="actions-btn bs-select-all btn ' + j.BUTTONCLASS + '">' + this.options.selectAllText + '</button><button type="button" class="actions-btn bs-deselect-all btn ' + j.BUTTONCLASS + '">' + this.options.deselectAllText + "</button></div></div>"), this.multiple && this.options.doneButton && (a = '<div class="bs-donebutton"><div class="btn-group btn-block"><button type="button" class="btn btn-sm ' + j.BUTTONCLASS + '">' + this.options.doneButtonText + "</button></div></div>"), n = '<div class="dropdown bootstrap-select' + e + i + '"><button type="button" class="' + this.options.styleBase + ' dropdown-toggle" ' + ("static" === this.options.display ? 'data-display="static"' : "") + 'data-toggle="dropdown"' + s + ' role="combobox" aria-owns="' + this.selectId + '" aria-haspopup="listbox" aria-expanded="false"><div class="filter-option"><div class="filter-option-inner"><div class="filter-option-inner-inner"></div></div> </div>' + ("4" === M.major ? "" : '<span class="bs-caret">' + this.options.template.caret + "</span>") + '</button><div class="' + j.MENU + " " + ("4" === M.major ? "" : j.SHOW) + '">' + o + r + l + '<div class="inner ' + j.SHOW + '" role="listbox" id="' + this.selectId + '" tabindex="-1" ' + t + '><ul class="' + j.MENU + " inner " + ("4" === M.major ? j.SHOW : "") + '" role="presentation"></ul></div>' + a + "</div></div>", z(n)
+            },
+            setPositionData: function() {
+                this.selectpicker.view.canHighlight = [];
+                for (var e = this.selectpicker.view.size = 0; e < this.selectpicker.current.data.length; e++) {
+                    var t = this.selectpicker.current.data[e],
+                        i = !0;
+                    "divider" === t.type ? (i = !1, t.height = this.sizeInfo.dividerHeight) : "optgroup-label" === t.type ? (i = !1, t.height = this.sizeInfo.dropdownHeaderHeight) : t.height = this.sizeInfo.liHeight, t.disabled && (i = !1), this.selectpicker.view.canHighlight.push(i), i && (this.selectpicker.view.size++, t.posinset = this.selectpicker.view.size), t.position = (0 === e ? 0 : this.selectpicker.current.data[e - 1].position) + t.height
+                }
+            },
+            isVirtual: function() {
+                return !1 !== this.options.virtualScroll && this.selectpicker.main.elements.length >= this.options.virtualScroll || !0 === this.options.virtualScroll
+            },
+            createView: function(A, e, t) {
+                var L, N, D = this,
+                    i = 0,
+                    H = [];
+                if (this.selectpicker.current = A ? this.selectpicker.search : this.selectpicker.main, this.setPositionData(), e)
+                    if (t) i = this.$menuInner[0].scrollTop;
+                    else if (!D.multiple) {
+                    var s = D.$element[0],
+                        n = (s.options[s.selectedIndex] || {}).liIndex;
+                    if ("number" == typeof n && !1 !== D.options.size) {
+                        var o = D.selectpicker.main.data[n],
+                            r = o && o.position;
+                        r && (i = r - (D.sizeInfo.menuInnerHeight + D.sizeInfo.liHeight) / 2)
+                    }
+                }
+
+                function l(e, t) {
+                    var i, s, n, o, r, l, a, c, d, h, p = D.selectpicker.current.elements.length,
+                        u = [],
+                        f = !0,
+                        m = D.isVirtual();
+                    D.selectpicker.view.scrollTop = e, !0 === m && D.sizeInfo.hasScrollBar && D.$menu[0].offsetWidth > D.sizeInfo.totalMenuWidth && (D.sizeInfo.menuWidth = D.$menu[0].offsetWidth, D.sizeInfo.totalMenuWidth = D.sizeInfo.menuWidth + D.sizeInfo.scrollBarWidth, D.$menu.css("min-width", D.sizeInfo.menuWidth)), i = Math.ceil(D.sizeInfo.menuInnerHeight / D.sizeInfo.liHeight * 1.5), s = Math.round(p / i) || 1;
+                    for (var v = 0; v < s; v++) {
+                        var g = (v + 1) * i;
+                        if (v === s - 1 && (g = p), u[v] = [v * i + (v ? 1 : 0), g], !p) break;
+                        void 0 === r && e <= D.selectpicker.current.data[g - 1].position - D.sizeInfo.menuInnerHeight && (r = v)
+                    }
+                    if (void 0 === r && (r = 0), l = [D.selectpicker.view.position0, D.selectpicker.view.position1], n = Math.max(0, r - 1), o = Math.min(s - 1, r + 1), D.selectpicker.view.position0 = !1 === m ? 0 : Math.max(0, u[n][0]) || 0, D.selectpicker.view.position1 = !1 === m ? p : Math.min(p, u[o][1]) || 0, a = l[0] !== D.selectpicker.view.position0 || l[1] !== D.selectpicker.view.position1, void 0 !== D.activeIndex && (N = D.selectpicker.main.elements[D.prevActiveIndex], H = D.selectpicker.main.elements[D.activeIndex], L = D.selectpicker.main.elements[D.selectedIndex], t && (D.activeIndex !== D.selectedIndex && D.defocusItem(H), D.activeIndex = void 0), D.activeIndex && D.activeIndex !== D.selectedIndex && D.defocusItem(L)), void 0 !== D.prevActiveIndex && D.prevActiveIndex !== D.activeIndex && D.prevActiveIndex !== D.selectedIndex && D.defocusItem(N), (t || a) && (c = D.selectpicker.view.visibleElements ? D.selectpicker.view.visibleElements.slice() : [], D.selectpicker.view.visibleElements = !1 === m ? D.selectpicker.current.elements : D.selectpicker.current.elements.slice(D.selectpicker.view.position0, D.selectpicker.view.position1), D.setOptionStatus(), (A || !1 === m && t) && (d = c, h = D.selectpicker.view.visibleElements, f = !(d.length === h.length && d.every(function(e, t) {
+                            return e === h[t]
+                        }))), (t || !0 === m) && f)) {
+                        var b, w, I = D.$menuInner[0],
+                            x = document.createDocumentFragment(),
+                            k = I.firstChild.cloneNode(!1),
+                            $ = D.selectpicker.view.visibleElements,
+                            y = [];
+                        I.replaceChild(k, I.firstChild);
+                        v = 0;
+                        for (var S = $.length; v < S; v++) {
+                            var E, C, O = $[v];
+                            D.options.sanitize && (E = O.lastChild) && (C = D.selectpicker.current.data[v + D.selectpicker.view.position0]) && C.content && !C.sanitized && (y.push(E), C.sanitized = !0), x.appendChild(O)
+                        }
+                        D.options.sanitize && y.length && P(y, D.options.whiteList, D.options.sanitizeFn), I.firstChild.style.marginBottom = !0 === m ? (b = 0 === D.selectpicker.view.position0 ? 0 : D.selectpicker.current.data[D.selectpicker.view.position0 - 1].position, w = D.selectpicker.view.position1 > p - 1 ? 0 : D.selectpicker.current.data[p - 1].position - D.selectpicker.current.data[D.selectpicker.view.position1 - 1].position, I.firstChild.style.marginTop = b + "px", w + "px") : I.firstChild.style.marginTop = 0, I.firstChild.appendChild(x)
+                    }
+                    if (D.prevActiveIndex = D.activeIndex, D.options.liveSearch) {
+                        if (A && t) {
+                            var z, T = 0;
+                            D.selectpicker.view.canHighlight[T] || (T = 1 + D.selectpicker.view.canHighlight.slice(1).indexOf(!0)), z = D.selectpicker.view.visibleElements[T], D.defocusItem(D.selectpicker.view.currentActive), D.activeIndex = (D.selectpicker.current.data[T] || {}).index, D.focusItem(z)
+                        }
+                    } else D.$menuInner.trigger("focus")
+                }
+                l(i, !0), this.$menuInner.off("scroll.createView").on("scroll.createView", function(e, t) {
+                    D.noScroll || l(this.scrollTop, t), D.noScroll = !1
+                }), z(window).off("resize" + U + "." + this.selectId + ".createView").on("resize" + U + "." + this.selectId + ".createView", function() {
+                    D.$newElement.hasClass(j.SHOW) && l(D.$menuInner[0].scrollTop)
+                })
+            },
+            focusItem: function(e, t, i) {
+                if (e) {
+                    t = t || this.selectpicker.main.data[this.activeIndex];
+                    var s = e.firstChild;
+                    s && (s.setAttribute("aria-setsize", this.selectpicker.view.size), s.setAttribute("aria-posinset", t.posinset), !0 !== i && (this.focusedParent.setAttribute("aria-activedescendant", s.id), e.classList.add("active"), s.classList.add("active")))
+                }
+            },
+            defocusItem: function(e) {
+                e && (e.classList.remove("active"), e.firstChild && e.firstChild.classList.remove("active"))
+            },
+            setPlaceholder: function() {
+                var e = !1;
+                if (this.options.title && !this.multiple) {
+                    this.selectpicker.view.titleOption || (this.selectpicker.view.titleOption = document.createElement("option")), e = !0;
+                    var t = this.$element[0],
+                        i = !1,
+                        s = !this.selectpicker.view.titleOption.parentNode;
+                    if (s) this.selectpicker.view.titleOption.className = "bs-title-option", this.selectpicker.view.titleOption.value = "", i = void 0 === z(t.options[t.selectedIndex]).attr("selected") && void 0 === this.$element.data("selected");
+                    (s || 0 !== this.selectpicker.view.titleOption.index) && t.insertBefore(this.selectpicker.view.titleOption, t.firstChild), i && (t.selectedIndex = 0)
+                }
+                return e
+            },
+            createLi: function() {
+                var c = this,
+                    f = this.options.iconBase,
+                    m = ':not([hidden]):not([data-hidden="true"])',
+                    v = [],
+                    g = [],
+                    d = 0,
+                    b = 0,
+                    e = this.setPlaceholder() ? 1 : 0;
+                this.options.hideDisabled && (m += ":not(:disabled)"), !c.options.showTick && !c.multiple || F.checkMark.parentNode || (F.checkMark.className = f + " " + c.options.tickIcon + " check-mark", F.a.appendChild(F.checkMark));
+                var t = this.$element[0].querySelectorAll("select > *" + m);
+
+                function w(e) {
+                    var t = g[g.length - 1];
+                    t && "divider" === t.type && (t.optID || e.optID) || ((e = e || {}).type = "divider", v.push(q(!1, j.DIVIDER, e.optID ? e.optID + "div" : void 0)), g.push(e))
+                }
+
+                function I(e, t) {
+                    if ((t = t || {}).divider = "true" === e.getAttribute("data-divider"), t.divider) w({
+                        optID: t.optID
+                    });
+                    else {
+                        var i = g.length,
+                            s = e.style.cssText,
+                            n = s ? E(s) : "",
+                            o = (e.className || "") + (t.optgroupClass || "");
+                        t.optID && (o = "opt " + o), t.text = e.textContent, t.content = e.getAttribute("data-content"), t.tokens = e.getAttribute("data-tokens"), t.subtext = e.getAttribute("data-subtext"), t.icon = e.getAttribute("data-icon"), t.iconBase = f;
+                        var r = Y(t),
+                            l = q(K(r, o, n), "", t.optID);
+                        l.firstChild && (l.firstChild.id = c.selectId + "-" + i), v.push(l), e.liIndex = i, t.display = t.content || t.text, t.type = "option", t.index = i, t.option = e, t.disabled = t.disabled || e.disabled, g.push(t);
+                        var a = 0;
+                        t.display && (a += t.display.length), t.subtext && (a += t.subtext.length), t.icon && (a += 1), d < a && (d = a, c.selectpicker.view.widestOption = v[v.length - 1])
+                    }
+                }
+
+                function i(e, t) {
+                    var i = t[e],
+                        s = t[e - 1],
+                        n = t[e + 1],
+                        o = i.querySelectorAll("option" + m);
+                    if (o.length) {
+                        var r, l, a = {
+                                label: E(i.label),
+                                subtext: i.getAttribute("data-subtext"),
+                                icon: i.getAttribute("data-icon"),
+                                iconBase: f
+                            },
+                            c = " " + (i.className || "");
+                        b++, s && w({
+                            optID: b
+                        });
+                        var d = Z(a);
+                        v.push(q(d, "dropdown-header" + c, b)), g.push({
+                            display: a.label,
+                            subtext: a.subtext,
+                            type: "optgroup-label",
+                            optID: b
+                        });
+                        for (var h = 0, p = o.length; h < p; h++) {
+                            var u = o[h];
+                            0 === h && (l = (r = g.length - 1) + p), I(u, {
+                                headerIndex: r,
+                                lastIndex: l,
+                                optID: b,
+                                optgroupClass: c,
+                                disabled: i.disabled
+                            })
+                        }
+                        n && w({
+                            optID: b
+                        })
+                    }
+                }
+                for (var s = t.length; e < s; e++) {
+                    var n = t[e];
+                    "OPTGROUP" !== n.tagName ? I(n, {}) : i(e, t)
+                }
+                this.selectpicker.main.elements = v, this.selectpicker.main.data = g, this.selectpicker.current = this.selectpicker.main
+            },
+            findLis: function() {
+                return this.$menuInner.find(".inner > li")
+            },
+            render: function() {
+                this.setPlaceholder();
+                var e, t, i = this,
+                    s = this.$element[0],
+                    n = function(e, t) {
+                        var i, s = e.selectedOptions,
+                            n = [];
+                        if (t) {
+                            for (var o = 0, r = s.length; o < r; o++)(i = s[o]).disabled || "OPTGROUP" === i.parentNode.tagName && i.parentNode.disabled || n.push(i);
+                            return n
+                        }
+                        return s
+                    }(s, this.options.hideDisabled),
+                    o = n.length,
+                    r = this.$button[0],
+                    l = r.querySelector(".filter-option-inner-inner"),
+                    a = document.createTextNode(this.options.multipleSeparator),
+                    c = F.fragment.cloneNode(!1),
+                    d = !1;
+                if (r.classList.toggle("bs-placeholder", i.multiple ? !o : !O(s, n)), this.tabIndex(), "static" === this.options.selectedTextFormat) c = Y({
+                    text: this.options.title
+                }, !0);
+                else if ((e = this.multiple && -1 !== this.options.selectedTextFormat.indexOf("count") && 1 < o) && (e = 1 < (t = this.options.selectedTextFormat.split(">")).length && o > t[1] || 1 === t.length && 2 <= o), !1 === e) {
+                    for (var h = 0; h < o && h < 50; h++) {
+                        var p = n[h],
+                            u = {},
+                            f = {
+                                content: p.getAttribute("data-content"),
+                                subtext: p.getAttribute("data-subtext"),
+                                icon: p.getAttribute("data-icon")
+                            };
+                        this.multiple && 0 < h && c.appendChild(a.cloneNode(!1)), p.title ? u.text = p.title : f.content && i.options.showContent ? (u.content = f.content.toString(), d = !0) : (i.options.showIcon && (u.icon = f.icon, u.iconBase = this.options.iconBase), i.options.showSubtext && !i.multiple && f.subtext && (u.subtext = " " + f.subtext), u.text = p.textContent.trim()), c.appendChild(Y(u, !0))
+                    }
+                    49 < o && c.appendChild(document.createTextNode("..."))
+                } else {
+                    var m = ':not([hidden]):not([data-hidden="true"]):not([data-divider="true"])';
+                    this.options.hideDisabled && (m += ":not(:disabled)");
+                    var v = this.$element[0].querySelectorAll("select > option" + m + ", optgroup" + m + " option" + m).length,
+                        g = "function" == typeof this.options.countSelectedText ? this.options.countSelectedText(o, v) : this.options.countSelectedText;
+                    c = Y({
+                        text: g.replace("{0}", o.toString()).replace("{1}", v.toString())
+                    }, !0)
+                }
+                if (null == this.options.title && (this.options.title = this.$element.attr("title")), c.childNodes.length || (c = Y({
+                        text: void 0 !== this.options.title ? this.options.title : this.options.noneSelectedText
+                    }, !0)), r.title = c.textContent.replace(/<[^>]*>?/g, "").trim(), this.options.sanitize && d && P([c], i.options.whiteList, i.options.sanitizeFn), l.innerHTML = "", l.appendChild(c), M.major < 4 && this.$newElement[0].classList.contains("bs3-has-addon")) {
+                    var b = r.querySelector(".filter-expand"),
+                        w = l.cloneNode(!0);
+                    w.className = "filter-expand", b ? r.replaceChild(w, b) : r.appendChild(w)
+                }
+                this.$element.trigger("rendered" + U)
+            },
+            setStyle: function(e, t) {
+                var i, s = this.$button[0],
+                    n = this.$newElement[0],
+                    o = this.options.style.trim();
+                this.$element.attr("class") && this.$newElement.addClass(this.$element.attr("class").replace(/selectpicker|mobile-device|bs-select-hidden|validate\[.*\]/gi, "")), M.major < 4 && (n.classList.add("bs3"), n.parentNode.classList.contains("input-group") && (n.previousElementSibling || n.nextElementSibling) && (n.previousElementSibling || n.nextElementSibling).classList.contains("input-group-addon") && n.classList.add("bs3-has-addon")), i = e ? e.trim() : o, "add" == t ? i && s.classList.add.apply(s.classList, i.split(" ")) : "remove" == t ? i && s.classList.remove.apply(s.classList, i.split(" ")) : (o && s.classList.remove.apply(s.classList, o.split(" ")), i && s.classList.add.apply(s.classList, i.split(" ")))
+            },
+            liHeight: function(e) {
+                if (e || !1 !== this.options.size && !this.sizeInfo) {
+                    this.sizeInfo || (this.sizeInfo = {});
+                    var t = document.createElement("div"),
+                        i = document.createElement("div"),
+                        s = document.createElement("div"),
+                        n = document.createElement("ul"),
+                        o = document.createElement("li"),
+                        r = document.createElement("li"),
+                        l = document.createElement("li"),
+                        a = document.createElement("a"),
+                        c = document.createElement("span"),
+                        d = this.options.header && 0 < this.$menu.find("." + j.POPOVERHEADER).length ? this.$menu.find("." + j.POPOVERHEADER)[0].cloneNode(!0) : null,
+                        h = this.options.liveSearch ? document.createElement("div") : null,
+                        p = this.options.actionsBox && this.multiple && 0 < this.$menu.find(".bs-actionsbox").length ? this.$menu.find(".bs-actionsbox")[0].cloneNode(!0) : null,
+                        u = this.options.doneButton && this.multiple && 0 < this.$menu.find(".bs-donebutton").length ? this.$menu.find(".bs-donebutton")[0].cloneNode(!0) : null,
+                        f = this.$element.find("option")[0];
+                    if (this.sizeInfo.selectWidth = this.$newElement[0].offsetWidth, c.className = "text", a.className = "dropdown-item " + (f ? f.className : ""), t.className = this.$menu[0].parentNode.className + " " + j.SHOW, t.style.width = this.sizeInfo.selectWidth + "px", "auto" === this.options.width && (i.style.minWidth = 0), i.className = j.MENU + " " + j.SHOW, s.className = "inner " + j.SHOW, n.className = j.MENU + " inner " + ("4" === M.major ? j.SHOW : ""), o.className = j.DIVIDER, r.className = "dropdown-header", c.appendChild(document.createTextNode("\u200b")), a.appendChild(c), l.appendChild(a), r.appendChild(c.cloneNode(!0)), this.selectpicker.view.widestOption && n.appendChild(this.selectpicker.view.widestOption.cloneNode(!0)), n.appendChild(l), n.appendChild(o), n.appendChild(r), d && i.appendChild(d), h) {
+                        var m = document.createElement("input");
+                        h.className = "bs-searchbox", m.className = "form-control", h.appendChild(m), i.appendChild(h)
+                    }
+                    p && i.appendChild(p), s.appendChild(n), i.appendChild(s), u && i.appendChild(u), t.appendChild(i), document.body.appendChild(t);
+                    var v, g = l.offsetHeight,
+                        b = r ? r.offsetHeight : 0,
+                        w = d ? d.offsetHeight : 0,
+                        I = h ? h.offsetHeight : 0,
+                        x = p ? p.offsetHeight : 0,
+                        k = u ? u.offsetHeight : 0,
+                        $ = z(o).outerHeight(!0),
+                        y = !!window.getComputedStyle && window.getComputedStyle(i),
+                        S = i.offsetWidth,
+                        E = y ? null : z(i),
+                        C = {
+                            vert: A(y ? y.paddingTop : E.css("paddingTop")) + A(y ? y.paddingBottom : E.css("paddingBottom")) + A(y ? y.borderTopWidth : E.css("borderTopWidth")) + A(y ? y.borderBottomWidth : E.css("borderBottomWidth")),
+                            horiz: A(y ? y.paddingLeft : E.css("paddingLeft")) + A(y ? y.paddingRight : E.css("paddingRight")) + A(y ? y.borderLeftWidth : E.css("borderLeftWidth")) + A(y ? y.borderRightWidth : E.css("borderRightWidth"))
+                        },
+                        O = {
+                            vert: C.vert + A(y ? y.marginTop : E.css("marginTop")) + A(y ? y.marginBottom : E.css("marginBottom")) + 2,
+                            horiz: C.horiz + A(y ? y.marginLeft : E.css("marginLeft")) + A(y ? y.marginRight : E.css("marginRight")) + 2
+                        };
+                    s.style.overflowY = "scroll", v = i.offsetWidth - S, document.body.removeChild(t), this.sizeInfo.liHeight = g, this.sizeInfo.dropdownHeaderHeight = b, this.sizeInfo.headerHeight = w, this.sizeInfo.searchHeight = I, this.sizeInfo.actionsHeight = x, this.sizeInfo.doneButtonHeight = k, this.sizeInfo.dividerHeight = $, this.sizeInfo.menuPadding = C, this.sizeInfo.menuExtras = O, this.sizeInfo.menuWidth = S, this.sizeInfo.totalMenuWidth = this.sizeInfo.menuWidth, this.sizeInfo.scrollBarWidth = v, this.sizeInfo.selectHeight = this.$newElement[0].offsetHeight, this.setPositionData()
+                }
+            },
+            getSelectPosition: function() {
+                var e, t = z(window),
+                    i = this.$newElement.offset(),
+                    s = z(this.options.container);
+                this.options.container && s.length && !s.is("body") ? ((e = s.offset()).top += parseInt(s.css("borderTopWidth")), e.left += parseInt(s.css("borderLeftWidth"))) : e = {
+                    top: 0,
+                    left: 0
+                };
+                var n = this.options.windowPadding;
+                this.sizeInfo.selectOffsetTop = i.top - e.top - t.scrollTop(), this.sizeInfo.selectOffsetBot = t.height() - this.sizeInfo.selectOffsetTop - this.sizeInfo.selectHeight - e.top - n[2], this.sizeInfo.selectOffsetLeft = i.left - e.left - t.scrollLeft(), this.sizeInfo.selectOffsetRight = t.width() - this.sizeInfo.selectOffsetLeft - this.sizeInfo.selectWidth - e.left - n[1], this.sizeInfo.selectOffsetTop -= n[0], this.sizeInfo.selectOffsetLeft -= n[3]
+            },
+            setMenuSize: function(e) {
+                this.getSelectPosition();
+                var t, i, s, n, o, r, l, a = this.sizeInfo.selectWidth,
+                    c = this.sizeInfo.liHeight,
+                    d = this.sizeInfo.headerHeight,
+                    h = this.sizeInfo.searchHeight,
+                    p = this.sizeInfo.actionsHeight,
+                    u = this.sizeInfo.doneButtonHeight,
+                    f = this.sizeInfo.dividerHeight,
+                    m = this.sizeInfo.menuPadding,
+                    v = 0;
+                if (this.options.dropupAuto && (l = c * this.selectpicker.current.elements.length + m.vert, this.$newElement.toggleClass(j.DROPUP, this.sizeInfo.selectOffsetTop - this.sizeInfo.selectOffsetBot > this.sizeInfo.menuExtras.vert && l + this.sizeInfo.menuExtras.vert + 50 > this.sizeInfo.selectOffsetBot)), "auto" === this.options.size) n = 3 < this.selectpicker.current.elements.length ? 3 * this.sizeInfo.liHeight + this.sizeInfo.menuExtras.vert - 2 : 0, i = this.sizeInfo.selectOffsetBot - this.sizeInfo.menuExtras.vert, s = n + d + h + p + u, r = Math.max(n - m.vert, 0), this.$newElement.hasClass(j.DROPUP) && (i = this.sizeInfo.selectOffsetTop - this.sizeInfo.menuExtras.vert), t = (o = i) - d - h - p - u - m.vert;
+                else if (this.options.size && "auto" != this.options.size && this.selectpicker.current.elements.length > this.options.size) {
+                    for (var g = 0; g < this.options.size; g++) "divider" === this.selectpicker.current.data[g].type && v++;
+                    t = (i = c * this.options.size + v * f + m.vert) - m.vert, o = i + d + h + p + u, s = r = ""
+                }
+                "auto" === this.options.dropdownAlignRight && this.$menu.toggleClass(j.MENURIGHT, this.sizeInfo.selectOffsetLeft > this.sizeInfo.selectOffsetRight && this.sizeInfo.selectOffsetRight < this.sizeInfo.totalMenuWidth - a), this.$menu.css({
+                    "max-height": o + "px",
+                    overflow: "hidden",
+                    "min-height": s + "px"
+                }), this.$menuInner.css({
+                    "max-height": t + "px",
+                    "overflow-y": "auto",
+                    "min-height": r + "px"
+                }), this.sizeInfo.menuInnerHeight = Math.max(t, 1), this.selectpicker.current.data.length && this.selectpicker.current.data[this.selectpicker.current.data.length - 1].position > this.sizeInfo.menuInnerHeight && (this.sizeInfo.hasScrollBar = !0, this.sizeInfo.totalMenuWidth = this.sizeInfo.menuWidth + this.sizeInfo.scrollBarWidth, this.$menu.css("min-width", this.sizeInfo.totalMenuWidth)), this.dropdown && this.dropdown._popper && this.dropdown._popper.update()
+            },
+            setSize: function(e) {
+                if (this.liHeight(e), this.options.header && this.$menu.css("padding-top", 0), !1 !== this.options.size) {
+                    var t = this,
+                        i = z(window);
+                    this.setMenuSize(), this.options.liveSearch && this.$searchbox.off("input.setMenuSize propertychange.setMenuSize").on("input.setMenuSize propertychange.setMenuSize", function() {
+                        return t.setMenuSize()
+                    }), "auto" === this.options.size ? i.off("resize" + U + "." + this.selectId + ".setMenuSize scroll" + U + "." + this.selectId + ".setMenuSize").on("resize" + U + "." + this.selectId + ".setMenuSize scroll" + U + "." + this.selectId + ".setMenuSize", function() {
+                        return t.setMenuSize()
+                    }) : this.options.size && "auto" != this.options.size && this.selectpicker.current.elements.length > this.options.size && i.off("resize" + U + "." + this.selectId + ".setMenuSize scroll" + U + "." + this.selectId + ".setMenuSize"), t.createView(!1, !0, e)
+                }
+            },
+            setWidth: function() {
+                var i = this;
+                "auto" === this.options.width ? requestAnimationFrame(function() {
+                    i.$menu.css("min-width", "0"), i.$element.on("loaded" + U, function() {
+                        i.liHeight(), i.setMenuSize();
+                        var e = i.$newElement.clone().appendTo("body"),
+                            t = e.css("width", "auto").children("button").outerWidth();
+                        e.remove(), i.sizeInfo.selectWidth = Math.max(i.sizeInfo.totalMenuWidth, t), i.$newElement.css("width", i.sizeInfo.selectWidth + "px")
+                    })
+                }) : "fit" === this.options.width ? (this.$menu.css("min-width", ""), this.$newElement.css("width", "").addClass("fit-width")) : this.options.width ? (this.$menu.css("min-width", ""), this.$newElement.css("width", this.options.width)) : (this.$menu.css("min-width", ""), this.$newElement.css("width", "")), this.$newElement.hasClass("fit-width") && "fit" !== this.options.width && this.$newElement[0].classList.remove("fit-width")
+            },
+            selectPosition: function() {
+                this.$bsContainer = z('<div class="bs-container" />');
+                var s, n, o, r = this,
+                    l = z(this.options.container),
+                    e = function(e) {
+                        var t = {},
+                            i = r.options.display || !!z.fn.dropdown.Constructor.Default && z.fn.dropdown.Constructor.Default.display;
+                        r.$bsContainer.addClass(e.attr("class").replace(/form-control|fit-width/gi, "")).toggleClass(j.DROPUP, e.hasClass(j.DROPUP)), s = e.offset(), l.is("body") ? n = {
+                            top: 0,
+                            left: 0
+                        } : ((n = l.offset()).top += parseInt(l.css("borderTopWidth")) - l.scrollTop(), n.left += parseInt(l.css("borderLeftWidth")) - l.scrollLeft()), o = e.hasClass(j.DROPUP) ? 0 : e[0].offsetHeight, (M.major < 4 || "static" === i) && (t.top = s.top - n.top + o, t.left = s.left - n.left), t.width = e[0].offsetWidth, r.$bsContainer.css(t)
+                    };
+                this.$button.on("click.bs.dropdown.data-api", function() {
+                    r.isDisabled() || (e(r.$newElement), r.$bsContainer.appendTo(r.options.container).toggleClass(j.SHOW, !r.$button.hasClass(j.SHOW)).append(r.$menu))
+                }), z(window).off("resize" + U + "." + this.selectId + " scroll" + U + "." + this.selectId).on("resize" + U + "." + this.selectId + " scroll" + U + "." + this.selectId, function() {
+                    r.$newElement.hasClass(j.SHOW) && e(r.$newElement)
+                }), this.$element.on("hide" + U, function() {
+                    r.$menu.data("height", r.$menu.height()), r.$bsContainer.detach()
+                })
+            },
+            setOptionStatus: function(e) {
+                var t = this;
+                if (t.noScroll = !1, t.selectpicker.view.visibleElements && t.selectpicker.view.visibleElements.length)
+                    for (var i = 0; i < t.selectpicker.view.visibleElements.length; i++) {
+                        var s = t.selectpicker.current.data[i + t.selectpicker.view.position0],
+                            n = s.option;
+                        n && (!0 !== e && t.setDisabled(s.index, s.disabled), t.setSelected(s.index, n.selected))
+                    }
+            },
+            setSelected: function(e, t) {
+                var i, s, n = this.selectpicker.main.elements[e],
+                    o = this.selectpicker.main.data[e],
+                    r = void 0 !== this.activeIndex,
+                    l = this.activeIndex === e || t && !this.multiple && !r;
+                o.selected = t, s = n.firstChild, t && (this.selectedIndex = e), n.classList.toggle("selected", t), l ? (this.focusItem(n, o), this.selectpicker.view.currentActive = n, this.activeIndex = e) : this.defocusItem(n), s && (s.classList.toggle("selected", t), t ? s.setAttribute("aria-selected", !0) : this.multiple ? s.setAttribute("aria-selected", !1) : s.removeAttribute("aria-selected")), l || r || !t || void 0 === this.prevActiveIndex || (i = this.selectpicker.main.elements[this.prevActiveIndex], this.defocusItem(i))
+            },
+            setDisabled: function(e, t) {
+                var i, s = this.selectpicker.main.elements[e];
+                this.selectpicker.main.data[e].disabled = t, i = s.firstChild, s.classList.toggle(j.DISABLED, t), i && ("4" === M.major && i.classList.toggle(j.DISABLED, t), t ? (i.setAttribute("aria-disabled", t), i.setAttribute("tabindex", -1)) : (i.removeAttribute("aria-disabled"), i.setAttribute("tabindex", 0)))
+            },
+            isDisabled: function() {
+                return this.$element[0].disabled
+            },
+            checkDisabled: function() {
+                var e = this;
+                this.isDisabled() ? (this.$newElement[0].classList.add(j.DISABLED), this.$button.addClass(j.DISABLED).attr("tabindex", -1).attr("aria-disabled", !0)) : (this.$button[0].classList.contains(j.DISABLED) && (this.$newElement[0].classList.remove(j.DISABLED), this.$button.removeClass(j.DISABLED).attr("aria-disabled", !1)), -1 != this.$button.attr("tabindex") || this.$element.data("tabindex") || this.$button.removeAttr("tabindex")), this.$button.on("click", function() {
+                    return !e.isDisabled()
+                })
+            },
+            tabIndex: function() {
+                this.$element.data("tabindex") !== this.$element.attr("tabindex") && -98 !== this.$element.attr("tabindex") && "-98" !== this.$element.attr("tabindex") && (this.$element.data("tabindex", this.$element.attr("tabindex")), this.$button.attr("tabindex", this.$element.data("tabindex"))), this.$element.attr("tabindex", -98)
+            },
+            clickListener: function() {
+                var C = this,
+                    t = z(document);
+
+                function e() {
+                    C.options.liveSearch ? C.$searchbox.trigger("focus") : C.$menuInner.trigger("focus")
+                }
+
+                function i() {
+                    C.dropdown && C.dropdown._popper && C.dropdown._popper.state.isCreated ? e() : requestAnimationFrame(i)
+                }
+                t.data("spaceSelect", !1), this.$button.on("keyup", function(e) {
+                    /(32)/.test(e.keyCode.toString(10)) && t.data("spaceSelect") && (e.preventDefault(), t.data("spaceSelect", !1))
+                }), this.$newElement.on("show.bs.dropdown", function() {
+                    3 < M.major && !C.dropdown && (C.dropdown = C.$button.data("bs.dropdown"), C.dropdown._menu = C.$menu[0])
+                }), this.$button.on("click.bs.dropdown.data-api", function() {
+                    C.$newElement.hasClass(j.SHOW) || C.setSize()
+                }), this.$element.on("shown" + U, function() {
+                    C.$menuInner[0].scrollTop !== C.selectpicker.view.scrollTop && (C.$menuInner[0].scrollTop = C.selectpicker.view.scrollTop), 3 < M.major ? requestAnimationFrame(i) : e()
+                }), this.$menuInner.on("mouseenter", "li a", function(e) {
+                    var t = this.parentElement,
+                        i = C.isVirtual() ? C.selectpicker.view.position0 : 0,
+                        s = Array.prototype.indexOf.call(t.parentElement.children, t),
+                        n = C.selectpicker.current.data[s + i];
+                    C.focusItem(t, n, !0)
+                }), this.$menuInner.on("click", "li a", function(e, t) {
+                    var i = z(this),
+                        s = C.$element[0],
+                        n = C.isVirtual() ? C.selectpicker.view.position0 : 0,
+                        o = C.selectpicker.current.data[i.parent().index() + n],
+                        r = o.index,
+                        l = O(s),
+                        a = s.selectedIndex,
+                        c = s.options[a],
+                        d = !0;
+                    if (C.multiple && 1 !== C.options.maxOptions && e.stopPropagation(), e.preventDefault(), !C.isDisabled() && !i.parent().hasClass(j.DISABLED)) {
+                        var h = C.$element.find("option"),
+                            p = o.option,
+                            u = z(p),
+                            f = p.selected,
+                            m = u.parent("optgroup"),
+                            v = m.find("option"),
+                            g = C.options.maxOptions,
+                            b = m.data("maxOptions") || !1;
+                        if (r === C.activeIndex && (t = !0), t || (C.prevActiveIndex = C.activeIndex, C.activeIndex = void 0), C.multiple) {
+                            C.clickinfo = e;
+                            if (p.selected = !f, C.setSelected(r, !f), i.trigger("blur"), !1 !== g || !1 !== b) {
+                                var w = g < h.filter(":selected").length,
+                                    I = b < m.find("option:selected").length;
+                                if (g && w || b && I)
+                                    if (g && 1 == g) {
+                                        h.prop("selected", !1), u.prop("selected", !0);
+                                        for (var x = 0; x < h.length; x++) C.setSelected(x, !1);
+                                        C.setSelected(r, !0)
+                                    } else if (b && 1 == b) {
+                                    m.find("option:selected").prop("selected", !1), u.prop("selected", !0);
+                                    for (x = 0; x < v.length; x++) {
+                                        p = v[x];
+                                        C.setSelected(h.index(p), !1)
+                                    }
+                                    C.setSelected(r, !0)
+                                } else {
+                                    var k = "string" == typeof C.options.maxOptionsText ? [C.options.maxOptionsText, C.options.maxOptionsText] : C.options.maxOptionsText,
+                                        $ = "function" == typeof k ? k(g, b) : k,
+                                        y = $[0].replace("{n}", g),
+                                        S = $[1].replace("{n}", b),
+                                        E = z('<div class="notify"></div>');
+                                    $[2] && (y = y.replace("{var}", $[2][1 < g ? 0 : 1]), S = S.replace("{var}", $[2][1 < b ? 0 : 1])), u.prop("selected", !1), C.$menu.append(E), g && w && (E.append(z("<div>" + y + "</div>")), d = !1, C.$element.trigger("maxReached" + U)), b && I && (E.append(z("<div>" + S + "</div>")), d = !1, C.$element.trigger("maxReachedGrp" + U)), setTimeout(function() {
+                                        C.setSelected(r, !1)
+                                    }, 10), E.delay(750).fadeOut(300, function() {
+                                        z(this).remove()
+                                    })
+                                }
+                            }
+                        } else c.selected = !1, p.selected = !0, C.setSelected(r, !0);
+                        !C.multiple || C.multiple && 1 === C.options.maxOptions ? C.$button.trigger("focus") : C.options.liveSearch && C.$searchbox.trigger("focus"), d && (C.multiple || a !== s.selectedIndex) && (T = [p.index, u.prop("selected"), l], C.$element.triggerNative("change"))
+                    }
+                }), this.$menu.on("click", "li." + j.DISABLED + " a, ." + j.POPOVERHEADER + ", ." + j.POPOVERHEADER + " :not(.close)", function(e) {
+                    e.currentTarget == this && (e.preventDefault(), e.stopPropagation(), C.options.liveSearch && !z(e.target).hasClass("close") ? C.$searchbox.trigger("focus") : C.$button.trigger("focus"))
+                }), this.$menuInner.on("click", ".divider, .dropdown-header", function(e) {
+                    e.preventDefault(), e.stopPropagation(), C.options.liveSearch ? C.$searchbox.trigger("focus") : C.$button.trigger("focus")
+                }), this.$menu.on("click", "." + j.POPOVERHEADER + " .close", function() {
+                    C.$button.trigger("click")
+                }), this.$searchbox.on("click", function(e) {
+                    e.stopPropagation()
+                }), this.$menu.on("click", ".actions-btn", function(e) {
+                    C.options.liveSearch ? C.$searchbox.trigger("focus") : C.$button.trigger("focus"), e.preventDefault(), e.stopPropagation(), z(this).hasClass("bs-select-all") ? C.selectAll() : C.deselectAll()
+                }), this.$element.on("change" + U, function() {
+                        console.log("change");
+                        if (C.clickinfo && C.multiple) {
+                            if (C.clickinfo.shiftKey) {
+                                console.log("C");
+                                console.log(C);
+                                console.log("T");
+                                console.log(T);
+                                if (T[1]) {
+                                    // This was just selected
+                                    var selshift = C.$element[0].options[T[0]].value
+
+                                	// This was selected previously
+                                	var selprevshift = "";
+                                	for (i = 1; i < C.$element[0].options.length; i++) {
+                                		var tmp = C.$element[0].options[i].value;
+                                		if (tmp == T[2][T[2].length-1]) {
+                                			selprevshift = i;
+                                		}
+                                	}
+                                	console.log("selshift " + T[0])
+                                	console.log("selprevshift " + selprevshift)
+
+                                    // get Indices of selections
+                                	var indexarr = {};
+                                	const fillRange = (start, end) => {
+                                      return Array(end - start + 1).fill().map((item, index) => start + index);
+                                    };
+                                	if (T[0] > selprevshift) {
+                                		indexarr = fillRange(selprevshift, T[0]);
+                                	} else {
+                                		indexarr = fillRange(T[0], selprevshift);
+                                	}
+
+                                    // Get Text of selections
+                                	console.log("indexarr " + indexarr);
+                                	var selectext = [];
+                                	for (i = 0; i < indexarr.length; i++) {
+                                		var obj = C.selectpicker.current.data[indexarr[i]].text;
+                                		selectext.push(obj);
+                                	}
+                                	if (T[2].length > 1) {
+                                	    T[2].pop();
+                                	    selectext = selectext.concat(T[2]);
+                                	}
+
+                                	C.val(selectext);
+                                }
+                            }
+                        }
+
+                    C.render(), C.$element.trigger("changed" + U, T), T = null
+                }).on("focus" + U, function() {
+                    C.options.mobile || C.$button.trigger("focus")
+                })
+            },
+            liveSearchListener: function() {
+                var u = this,
+                    f = document.createElement("li");
+                this.$button.on("click.bs.dropdown.data-api", function() {
+                    u.$searchbox.val() && u.$searchbox.val("")
+                }), this.$searchbox.on("click.bs.dropdown.data-api focus.bs.dropdown.data-api touchend.bs.dropdown.data-api", function(e) {
+                    e.stopPropagation()
+                }), this.$searchbox.on("input propertychange", function() {
+                    var e = u.$searchbox.val();
+                    if (u.selectpicker.search.elements = [], u.selectpicker.search.data = [], e) {
+                        var t = [],
+                            i = e.toUpperCase(),
+                            s = {},
+                            n = [],
+                            o = u._searchStyle(),
+                            r = u.options.liveSearchNormalize;
+                        r && (i = w(i)), u._$lisSelected = u.$menuInner.find(".selected");
+                        for (var l = 0; l < u.selectpicker.main.data.length; l++) {
+                            var a = u.selectpicker.main.data[l];
+                            s[l] || (s[l] = k(a, i, o, r)), s[l] && void 0 !== a.headerIndex && -1 === n.indexOf(a.headerIndex) && (0 < a.headerIndex && (s[a.headerIndex - 1] = !0, n.push(a.headerIndex - 1)), s[a.headerIndex] = !0, n.push(a.headerIndex), s[a.lastIndex + 1] = !0), s[l] && "optgroup-label" !== a.type && n.push(l)
+                        }
+                        l = 0;
+                        for (var c = n.length; l < c; l++) {
+                            var d = n[l],
+                                h = n[l - 1],
+                                p = (a = u.selectpicker.main.data[d], u.selectpicker.main.data[h]);
+                            ("divider" !== a.type || "divider" === a.type && p && "divider" !== p.type && c - 1 !== l) && (u.selectpicker.search.data.push(a), t.push(u.selectpicker.main.elements[d]))
+                        }
+                        u.activeIndex = void 0, u.noScroll = !0, u.$menuInner.scrollTop(0), u.selectpicker.search.elements = t, u.createView(!0), t.length || (f.className = "no-results", f.innerHTML = u.options.noneResultsText.replace("{0}", '"' + E(e) + '"'), u.$menuInner[0].firstChild.appendChild(f))
+                    } else u.$menuInner.scrollTop(0), u.createView(!1)
+                })
+            },
+            _searchStyle: function() {
+                return this.options.liveSearchStyle || "contains"
+            },
+            val: function(e) {
+                    console.log("val: ", e)
+                var t = this.$element[0];
+                if (void 0 === e) return this.$element.val();
+                var i = O(t);
+                if (T = [null, null, i], this.$element.val(e).trigger("changed" + U, T), this.$newElement.hasClass(j.SHOW))
+                    if (this.multiple) this.setOptionStatus(!0);
+                    else {
+                        var s = (t.options[t.selectedIndex] || {}).liIndex;
+                        "number" == typeof s && (this.setSelected(this.selectedIndex, !1), this.setSelected(s, !0))
+                    }
+                return this.render(), T = null, this.$element
+            },
+            changeAll: function(e) {
+                if (this.multiple) {
+                    void 0 === e && (e = !0);
+                    var t = this.$element[0],
+                        i = 0,
+                        s = 0,
+                        n = O(t);
+                    t.classList.add("bs-select-hidden");
+                    for (var o = 0, r = this.selectpicker.current.elements.length; o < r; o++) {
+                        var l = this.selectpicker.current.data[o],
+                            a = l.option;
+                        a && !l.disabled && "divider" !== l.type && (l.selected && i++, (a.selected = e) && s++)
+                    }
+                    t.classList.remove("bs-select-hidden"), i !== s && (this.setOptionStatus(), T = [null, null, n], this.$element.triggerNative("change"))
+                }
+            },
+            selectAll: function() {
+                return this.changeAll(!0)
+            },
+            deselectAll: function() {
+                return this.changeAll(!1)
+            },
+            toggle: function(e) {
+                    console.log("toggle: " + e)
+                (e = e || window.event) && e.stopPropagation(), this.$button.trigger("click.bs.dropdown.data-api")
+            },
+            keydown: function(e) {
+                var t, i, s, n, o, r = z(this),
+                    l = r.hasClass("dropdown-toggle"),
+                    a = (l ? r.closest(".dropdown") : r.closest(V.MENU)).data("this"),
+                    c = a.findLis(),
+                    d = !1,
+                    h = e.which === H && !l && !a.options.selectOnTab,
+                    p = _.test(e.which) || h,
+                    u = a.$menuInner[0].scrollTop,
+                    f = !0 === a.isVirtual() ? a.selectpicker.view.position0 : 0;
+                if (!(i = a.$newElement.hasClass(j.SHOW)) && (p || 48 <= e.which && e.which <= 57 || 96 <= e.which && e.which <= 105 || 65 <= e.which && e.which <= 90) && (a.$button.trigger("click.bs.dropdown.data-api"), a.options.liveSearch)) a.$searchbox.trigger("focus");
+                else {
+                    if (e.which === L && i && (e.preventDefault(), a.$button.trigger("click.bs.dropdown.data-api").trigger("focus")), p) {
+                        if (!c.length) return; - 1 !== (t = (s = a.selectpicker.main.elements[a.activeIndex]) ? Array.prototype.indexOf.call(s.parentElement.children, s) : -1) && a.defocusItem(s), e.which === B ? (-1 !== t && t--, t + f < 0 && (t += c.length), a.selectpicker.view.canHighlight[t + f] || -1 === (t = a.selectpicker.view.canHighlight.slice(0, t + f).lastIndexOf(!0) - f) && (t = c.length - 1)) : (e.which === W || h) && (++t + f >= a.selectpicker.view.canHighlight.length && (t = 0), a.selectpicker.view.canHighlight[t + f] || (t = t + 1 + a.selectpicker.view.canHighlight.slice(t + f + 1).indexOf(!0))), e.preventDefault();
+                        var m = f + t;
+                        e.which === B ? 0 === f && t === c.length - 1 ? (a.$menuInner[0].scrollTop = a.$menuInner[0].scrollHeight, m = a.selectpicker.current.elements.length - 1) : d = (o = (n = a.selectpicker.current.data[m]).position - n.height) < u : (e.which === W || h) && (0 === t ? m = a.$menuInner[0].scrollTop = 0 : d = u < (o = (n = a.selectpicker.current.data[m]).position - a.sizeInfo.menuInnerHeight)), s = a.selectpicker.current.elements[m], a.activeIndex = a.selectpicker.current.data[m].index, a.focusItem(s), a.selectpicker.view.currentActive = s, d && (a.$menuInner[0].scrollTop = o), a.options.liveSearch ? a.$searchbox.trigger("focus") : r.trigger("focus")
+                    } else if (!r.is("input") && !G.test(e.which) || e.which === D && a.selectpicker.keydown.keyHistory) {
+                        var v, g, b = [];
+                        e.preventDefault(), a.selectpicker.keydown.keyHistory += C[e.which], a.selectpicker.keydown.resetKeyHistory.cancel && clearTimeout(a.selectpicker.keydown.resetKeyHistory.cancel), a.selectpicker.keydown.resetKeyHistory.cancel = a.selectpicker.keydown.resetKeyHistory.start(), g = a.selectpicker.keydown.keyHistory, /^(.)\1+$/.test(g) && (g = g.charAt(0));
+                        for (var w = 0; w < a.selectpicker.current.data.length; w++) {
+                            var I = a.selectpicker.current.data[w];
+                            k(I, g, "startsWith", !0) && a.selectpicker.view.canHighlight[w] && b.push(I.index)
+                        }
+                        if (b.length) {
+                            var x = 0;
+                            c.removeClass("active").find("a").removeClass("active"), 1 === g.length && (-1 === (x = b.indexOf(a.activeIndex)) || x === b.length - 1 ? x = 0 : x++), v = b[x], d = 0 < u - (n = a.selectpicker.main.data[v]).position ? (o = n.position - n.height, !0) : (o = n.position - a.sizeInfo.menuInnerHeight, n.position > u + a.sizeInfo.menuInnerHeight), s = a.selectpicker.main.elements[v], a.activeIndex = b[x], a.focusItem(s), s && s.firstChild.focus(), d && (a.$menuInner[0].scrollTop = o), r.trigger("focus")
+                        }
+                    }
+                    i && (e.which === D && !a.selectpicker.keydown.keyHistory || e.which === N || e.which === H && a.options.selectOnTab) && (e.which !== D && e.preventDefault(), a.options.liveSearch && e.which === D || (a.$menuInner.find(".active a").trigger("click", !0), r.trigger("focus"), a.options.liveSearch || (e.preventDefault(), z(document).data("spaceSelect", !0))))
+                }
+            },
+            mobile: function() {
+                this.$element[0].classList.add("mobile-device")
+            },
+            refresh: function() {
+                var e = z.extend({}, this.options, this.$element.data());
+                this.options = e, this.checkDisabled(), this.setStyle(), this.render(), this.createLi(), this.setWidth(), this.setSize(!0), this.$element.trigger("refreshed" + U)
+            },
+            hide: function() {
+                this.$newElement.hide()
+            },
+            show: function() {
+                this.$newElement.show()
+            },
+            remove: function() {
+                this.$newElement.remove(), this.$element.remove()
+            },
+            destroy: function() {
+                this.$newElement.before(this.$element).remove(), this.$bsContainer ? this.$bsContainer.remove() : this.$menu.remove(), this.$element.off(U).removeData("selectpicker").removeClass("bs-select-hidden selectpicker"), z(window).off(U + "." + this.selectId)
+            }
+        };
+        var X = z.fn.selectpicker;
+        z.fn.selectpicker = Q, z.fn.selectpicker.Constructor = J, z.fn.selectpicker.noConflict = function() {
+            return z.fn.selectpicker = X, this
+        }, z(document).off("keydown.bs.dropdown.data-api").on("keydown" + U, '.bootstrap-select [data-toggle="dropdown"], .bootstrap-select [role="listbox"], .bootstrap-select .bs-searchbox input', J.prototype.keydown).on("focusin.modal", '.bootstrap-select [data-toggle="dropdown"], .bootstrap-select [role="listbox"], .bootstrap-select .bs-searchbox input', function(e) {
+            e.stopPropagation()
+        }), z(window).on("load" + U + ".data-api", function() {
+            z(".selectpicker").each(function() {
+                var e = z(this);
+                Q.call(e, e.data())
+            })
+        })
+    }(e)
+});
 //# sourceMappingURL=bootstrap-select.min.js.map

--- a/inst/www/selectPicker/js/bootstrap-select.min.js
+++ b/inst/www/selectPicker/js/bootstrap-select.min.js
@@ -1179,7 +1179,7 @@
                                 console.log(C);
                                 console.log("T");
                                 console.log(T);
-                                if (T[1]) {
+                                if (T[1] && T[2].length != 0) {
                                     // This was just selected
                                     var selshift = C.$element[0].options[T[0]].value
 

--- a/inst/www/selectPicker/js/bootstrap-select.min.js
+++ b/inst/www/selectPicker/js/bootstrap-select.min.js
@@ -1172,47 +1172,46 @@
                 }), this.$menu.on("click", ".actions-btn", function(e) {
                     C.options.liveSearch ? C.$searchbox.trigger("focus") : C.$button.trigger("focus"), e.preventDefault(), e.stopPropagation(), z(this).hasClass("bs-select-all") ? C.selectAll() : C.deselectAll()
                 }), this.$element.on("change" + U, function() {
-                        if (C.clickinfo && C.multiple) {
-                            if (C.clickinfo.shiftKey) {
-                                if (T[1] && T[2].length != 0) {
-                                    var k = C.selectpicker.current.data;
+                    if (C.clickinfo && C.multiple) {
+                        if (C.clickinfo.shiftKey) {
+                            if (T[1] && T[2].length != 0) {
+                                var k = C.selectpicker.current.data;
 
-                                    // This was just selected
-                                    var selshift = k[T[0]].text
+                                // This was just selected
+                                var selshift = k[T[0]].text
 
-                                	// This was selected previously
-                                	var selprevshift = k.filter(function(ki) {
-                                        return ki.text === T[2][T[2].length-1];
-                                    })[0].index;
+                                // This was selected previously
+                                var selprevshift = k.filter(function(ki) {
+                                    return ki.text === T[2][T[2].length-1];
+                                })[0].index;
 
-                                    // get Indices of selections
-                                	var indexarr = {};
-                                	const fillRange = (start, end) => {
-                                      return Array(end - start + 1).fill().map((item, index) => start + index);
-                                    };
-                                	if (T[0] > selprevshift) {
-                                		indexarr = fillRange(selprevshift, T[0]);
-                                	} else {
-                                		indexarr = fillRange(T[0], selprevshift);
-                                	}
-
-                                    // Get Text of selections
-                                	var selectext = [];
-                                	for (var i = 0; i < indexarr.length; i++) {
-                                		selectext.push(k[indexarr[i]].text);
-                                	}
-
-                                    // Add previous selections if available
-                                	if (T[2].length > 1) {
-                                	    selectext = selectext.concat(T[2]);
-                                	}
-
-                                    // Select items
-                                	C.val(selectext);
+                                // get Indices of selections
+                                var indexarr = {};
+                                const fillRange = (start, end) => {
+                                  return Array(end - start + 1).fill().map((item, index) => start + index);
+                                };
+                                if (T[0] > selprevshift) {
+                                    indexarr = fillRange(selprevshift, T[0]);
+                                } else {
+                                    indexarr = fillRange(T[0], selprevshift);
                                 }
+
+                                // Get Text of selections
+                                var selectext = [];
+                                for (var i = 0; i < indexarr.length; i++) {
+                                    selectext.push(k[indexarr[i]].text);
+                                }
+
+                                // Add previous selections if available
+                                if (T[2].length > 1) {
+                                    selectext = selectext.concat(T[2]);
+                                }
+
+                                // Select items
+                                C.val(selectext);
                             }
                         }
-
+                    }
                     C.render(), C.$element.trigger("changed" + U, T), T = null
                 }).on("focus" + U, function() {
                     C.options.mobile || C.$button.trigger("focus")

--- a/inst/www/selectPicker/js/bootstrap-select.min.js
+++ b/inst/www/selectPicker/js/bootstrap-select.min.js
@@ -1172,13 +1172,11 @@
                 }), this.$menu.on("click", ".actions-btn", function(e) {
                     C.options.liveSearch ? C.$searchbox.trigger("focus") : C.$button.trigger("focus"), e.preventDefault(), e.stopPropagation(), z(this).hasClass("bs-select-all") ? C.selectAll() : C.deselectAll()
                 }), this.$element.on("change" + U, function() {
-                        console.log("change");
+                        //console.log("change");
                         if (C.clickinfo && C.multiple) {
                             if (C.clickinfo.shiftKey) {
-                                console.log("C");
-                                console.log(C);
-                                console.log("T");
-                                console.log(T);
+                                //console.log("C"); console.log(C);
+                                //console.log("T"); console.log(T);
                                 if (T[1] && T[2].length != 0) {
                                     // This was just selected
                                     var selshift = C.$element[0].options[T[0]].value
@@ -1191,8 +1189,8 @@
                                 			selprevshift = i;
                                 		}
                                 	}
-                                	console.log("selshift " + T[0])
-                                	console.log("selprevshift " + selprevshift)
+                                	//console.log("selshift " + T[0])
+                                	//console.log("selprevshift " + selprevshift)
 
                                     // get Indices of selections
                                 	var indexarr = {};
@@ -1206,7 +1204,7 @@
                                 	}
 
                                     // Get Text of selections
-                                	console.log("indexarr " + indexarr);
+                                	//console.log("indexarr " + indexarr);
                                 	var selectext = [];
                                 	for (i = 0; i < indexarr.length; i++) {
                                 		var obj = C.selectpicker.current.data[indexarr[i]].text;
@@ -1263,7 +1261,7 @@
                 return this.options.liveSearchStyle || "contains"
             },
             val: function(e) {
-                    console.log("val: ", e)
+                    //console.log("val: ", e)
                 var t = this.$element[0];
                 if (void 0 === e) return this.$element.val();
                 var i = O(t);
@@ -1298,7 +1296,7 @@
                 return this.changeAll(!1)
             },
             toggle: function(e) {
-                    console.log("toggle: " + e)
+                    //console.log("toggle: " + e)
                 (e = e || window.event) && e.stopPropagation(), this.$button.trigger("click.bs.dropdown.data-api")
             },
             keydown: function(e) {


### PR DESCRIPTION
Makes a SHIFT-Selection possible and addresses #199 

I had to adapt the underlying `bootstrap-select.min.js` (which is now unminified). I know this might not be the best way also for maintaining future updates of bootstrap. I'll try to submit a working PR to `bootstrap-select` aswell, then `shinyWidget` would just need to get the new version.

Unfortunately it is not perfect:
Lets assume we have a selectPicker with a list from A-Z.
If I first select D and then I decide that I want to have everything from B to G, I would click B and with SHIFT pressed down click G, then the range selection would pick everything from D to G and not from B to G. 

But it allows for several SHIFT-selections.


```
library(shiny)
library(shinyWidgets)

ui <- fluidPage(
  pickerInput("asd", label = "Select from-to with SHIFT:",
              choices = LETTERS[1:20], multiple = TRUE, 
              options = pickerOptions(actionsBox = TRUE)),
  verbatimTextOutput("txt")
)

server <- function(input, output, session) {
  output$txt <- renderPrint({
    input$asd
  })
}

shinyApp(ui, server)
```