### PR TITLE
fix bug in default values for updateNumericRangeInput

### DIFF
--- a/R/input-numericRange.R
+++ b/R/input-numericRange.R
@@ -92,7 +92,7 @@ numericRangeInput <- function(inputId, label, value,
 #' @inheritParams numericRangeInput
 #' @export
 #'
-updateNumericRangeInput <- function(session, inputId, label, value) {
+updateNumericRangeInput <- function(session, inputId, label = NULL, value) {
 
   value <- c(min(value),max(value))
 

--- a/R/input-numericRange.R
+++ b/R/input-numericRange.R
@@ -92,7 +92,7 @@ numericRangeInput <- function(inputId, label, value,
 #' @inheritParams numericRangeInput
 #' @export
 #'
-updateNumericRangeInput <- function(session, inputId, label = NULL, value) {
+updateNumericRangeInput <- function(session, inputId, label = NULL, value = NULL) {
 
   value <- c(min(value),max(value))
 


### PR DESCRIPTION
when I originally wrote `updateNumericRangeInput()` I did not default the arguments `label` and `value` to `NULL` as is customary. This PR should fix that.