### PR TITLE
Allow for multiple = FALSE in selectizeGroup module.

### DIFF
--- a/R/module-selectizeGroup.R
+++ b/R/module-selectizeGroup.R
@@ -44,7 +44,7 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
                 label = input$title,
                 choices = input$choices,
                 selected = input$selected,
-                multiple = TRUE,
+                multiple = ifelse(is.null(input$multiple), TRUE, input$multiple),
                 width = "100%",
                 options = list(
                   placeholder = input$placeholder, plugins = list("remove_button"),
@@ -75,7 +75,7 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
             label = input$title,
             choices = input$choices,
             selected = input$selected,
-            multiple = TRUE,
+            multiple = ifelse(is.null(input$multiple), TRUE, input$multiple),
             width = "100%",
             options = list(
               placeholder = input$placeholder, plugins = list("remove_button"),


### PR DESCRIPTION
Hello :),

I need to control the option for one or more selectize input in my selectizeGroup.
I suggest this change to still have multiple = TRUE as default but allow the user to change this option. I did not check for multiple type (errors will happen if an user pass multiple param as something else than a logical) but this should not be a problem very often.. 

