### PR TITLE
Update test expectation to account for shiny's new sliderInput() dependencies

### DIFF
--- a/tests/testthat/test-sliderText.R
+++ b/tests/testthat/test-sliderText.R
@@ -11,7 +11,7 @@ test_that("default", {
   )
 
   expect_is(tagst, "shiny.tag")
-  expect_length(htmltools::findDependencies(tagst), 3)
+  expect_true(htmltools::findDependencies(tagst) >= 3)
   expect_identical(htmltools::findDependencies(tagst)[[1]]$script, "js/ion.rangeSlider.min.js")
   expect_true(htmltools::tagHasAttribute(tagst$children[[2]], "id"))
   expect_identical(htmltools::tagGetAttribute(tagst$children[[2]], "id"), "MY_ID")


### PR DESCRIPTION
Hi @pvictor, 

We plan on submitting shiny 1.6 to CRAN next week which will cause this unit test to fail ( because `sliderInput()` HTML dependencies are now separated into different JS/CSS dependencies). We'd really appreciate it if you could submit a new version of shinyWidgets as soon as possible to update this test expectation (it'd also be nice to also have https://github.com/dreamRs/shinyWidgets/pull/343 in the next release of shinyWidgets, but that's not as urgent as this patch fix). Let me know if you have any questions.

Thanks,

-Carson 