### PR TITLE
add transparent border to setSliderColor

### DIFF
--- a/R/setSliderColor.R
+++ b/R/setSliderColor.R
@@ -71,7 +71,7 @@ setSliderColor <- function(color, sliderId) {
       " .js-irs-", i, " .irs-to,",
       " .js-irs-", i, " .irs-bar-edge,",
       " .js-irs-", i,
-      " .irs-bar{background: ", color[i+1],
+      " .irs-bar{  border-color: transparent;background: ", color[i+1],
       "; border-top: 1px solid ", color[i+1],
       "; border-bottom: 1px solid ", color[i+1],
       ";}"


### PR DESCRIPTION
Hi lovely dreamRs! 👋 I don't make pull requests to public packages often, and I don't know much about CSS, so feedback is welcome.  😊

I really appreciate your `setSliderColor` function! I was using this function and noticed that the default border color on the slider is still blue, even when then slider color is set.

![image](https://user-images.githubusercontent.com/17747575/124187496-e7406b00-da8b-11eb-938f-51fedd855182.png)

I figured out that adding `border-color: transparent` to the function can remove the blue outline, which may be a preferable default for those changing their slider colors. (I have no idea if spacing or anything matters in the function!)

![image](https://user-images.githubusercontent.com/17747575/124187677-2cfd3380-da8c-11eb-99ba-dbba0ff1b8b2.png)

Just a thought! Thanks for considering.

