### PR TITLE
Switch to Font-Awesome 5 icon names

### DIFF
--- a/inst/examples/shinyWidgets/ui.R
+++ b/inst/examples/shinyWidgets/ui.R
@@ -58,9 +58,9 @@ sidebar <- dashboardSidebar(
     menuItem(text = "radio Buttons", tabName = "tabradioButtons", icon = icon("circle")),
     menuItem(text = "materialSwitch", tabName = "tabMaterialSwitch", icon = icon("toggle-off")),
     menuItem(text = "pickerInput", tabName = "tabPickerInput", icon = icon("caret-down")),
-    menuItem(text = "sliderText", tabName = "tabSliderText", icon = icon("sliders")),
+    menuItem(text = "sliderText", tabName = "tabSliderText", icon = icon("sliders-h")),
     menuItem(text = "progressBar", tabName = "tabProgressBars", icon = icon("tasks")),
-    menuItem(text = "bttn", tabName = "tabBttn", icon = icon("square-o")),
+    menuItem(text = "bttn", tabName = "tabBttn", icon = icon("square")),
     menuItem(text = "dropdowns & sweetalert", tabName = "tabOtherStuff", icon = icon("plus-circle"))
   )
 )
@@ -181,7 +181,7 @@ body <- dashboardBody(
                 inputId = ID(.shinyWidgetGalleryId), label = "Click search icon to update or hit 'Enter'",
                 placeholder = "A placeholder",
                 btnSearch = icon("search"),
-                btnReset = icon("remove"),
+                btnReset = icon("times"),
                 width = "100%"
               )
             )
@@ -431,7 +431,7 @@ body <- dashboardBody(
               args = list(inputId = ID(.shinyWidgetGalleryId),
                           label_on = "Yes!", icon_on = icon("check"),
                           status_on = "info", status_off = "warning",
-                          label_off = "No..", icon_off = icon("remove"))
+                          label_off = "No..", icon_off = icon("times"))
             )
           )
           ,
@@ -483,7 +483,7 @@ body <- dashboardBody(
             .shinyWidgetGalleryFuns$widget_wrapper(
               fun = prettyCheckboxGroup,
               args = list(inputId = ID(.shinyWidgetGalleryId), label = "Choose:", choices = c("Click me !", "Me !", "Or me !"),
-                          icon = icon("check-square-o"), status = "primary", outline = TRUE, animation = "jelly")
+                          icon = icon("check-square"), status = "primary", outline = TRUE, animation = "jelly")
             )
           )
           ,
@@ -1569,7 +1569,7 @@ body <- dashboardBody(
             title = NULL,
             .shinyWidgetGalleryFuns$widget_wrapper(
               fun = actionBttn,
-              args = list(inputId = ID(.shinyWidgetGalleryId), label = "bordered", style = "bordered", color = "success", icon = icon("sliders"))
+              args = list(inputId = ID(.shinyWidgetGalleryId), label = "bordered", style = "bordered", color = "success", icon = icon("sliders-h"))
             ),
             footer = NULL
           ),
@@ -1630,7 +1630,7 @@ body <- dashboardBody(
               selectInput(inputId = 'xcol', label = 'X Variable', choices = names(iris)),
               selectInput(inputId = 'ycol', label = 'Y Variable', choices = names(iris), selected = names(iris)[[2]]),
               sliderInput(inputId = 'clusters', label = 'Cluster count', value = 3, min = 1, max = 9),
-              circle = TRUE, status = "danger", icon = icon("gear"), width = "300px",
+              circle = TRUE, status = "danger", icon = icon("cog"), width = "300px",
               tooltip = tooltipOptions(title = "Click to see inputs !")
             ),
             plotOutput(outputId = 'plot1'),
@@ -1652,7 +1652,7 @@ body <- dashboardBody(
               pickerInput(inputId = 'xcol2', label = 'X Variable', choices = names(iris), options = list(`style` = "btn-info")),
               pickerInput(inputId = 'ycol2', label = 'Y Variable', choices = names(iris), selected = names(iris)[[2]], options = list(`style` = "btn-warning")),
               sliderInput(inputId = 'clusters2', label = 'Cluster count', value = 3, min = 1, max = 9),
-              style = "unite", icon = icon("gear"), status = "danger", width = "300px",
+              style = "unite", icon = icon("cog"), status = "danger", width = "300px",
               animate = animateOptions(enter = animations$fading_entrances$fadeInLeftBig, exit = animations$fading_exits$fadeOutRightBig)
             ),
             plotOutput(outputId = 'plot2'),


### PR DESCRIPTION
We are in the process of submitting Shiny 1.7.0 to CRAN, and we have found that this package has the following test failure:

```
> Package: shinyWidgets
> Check: tests
> New result: ERROR
>      Running â€˜testthat.Râ€™ [3s/3s]
>    Running the tests in â€˜tests/testthat.Râ€™ failed.
>    Complete output:
>      > library(testthat)
>      > library(shinyWidgets)
>      >
>      > test_check("shinyWidgets")
>      â• â•  Failed tests â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â• â•
>      â”€â”€ Failure (test-shinyWidgetsGallery.R:12:3): Default â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
>      `... <- NULL` produced messages.
>     
>      [ FAIL 1 | WARN 0 | SKIP 0 | PASS 286 ]
>      Error: Test failures
>      Execution halted
```

These are the messages:

```
>     ui <- source(file = system.file('examples/shinyWidgets/ui.R', package='shinyWidgets'))
The `name` provided ('sliders') is deprecated in Font Awesome 5:
* please consider using 'sliders-h' or 'fas fa-sliders-h' instead
* use the `verify_fa = FALSE` to deactivate these messages
This Font Awesome icon ('square-o') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
This Font Awesome icon ('remove') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
This Font Awesome icon ('remove') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
This Font Awesome icon ('check-square-o') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
The `name` provided ('sliders') is deprecated in Font Awesome 5:
* please consider using 'sliders-h' or 'fas fa-sliders-h' instead
* use the `verify_fa = FALSE` to deactivate these messages
This Font Awesome icon ('gear') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
This Font Awesome icon ('gear') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
```

These icon names were from Font-Awesome 4, and they have changed or been removed in Font-Awesome 5. In Shiny 1.7.0, we started using the [fontawesome](https://github.com/rstudio/fontawesome/) package, which prints out messages if these old icon names are used.

This PR uses the new FA5 icon names, so that the test passes.

Can you please accept these changes and release a new version of shinyWidgets within the next two weeks? If you can release it as soon as possible, we would appreciate it. This is a blocker for the release of the new version of Shiny.