### PR TITLE
Update module-selectizeGroup.R

### DIFF
--- a/R/module-selectizeGroup.R
+++ b/R/module-selectizeGroup.R
@@ -59,7 +59,7 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
       actionLink(
         inputId = ns("reset_all"),
         label = btn_label,
-        icon = icon("remove"),
+        icon = icon("times"),
         style = "float: right;"
       )
     )
@@ -88,7 +88,7 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
       actionLink(
         inputId = ns("reset_all"),
         label = btn_label,
-        icon = icon("remove"),
+        icon = icon("times"),
         style = "float: right;"
       )
     )


### PR DESCRIPTION
Using shiny 1.7.0 using `icon("remove")` gives:

This Font Awesome icon ('remove') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`

Switching to `icon("times")`