### PR TITLE
Fix #419 - wrap selectizeInputs in a container div and make selectizeGroupServer inline aware

### DIFF
--- a/R/module-selectizeGroup.R
+++ b/R/module-selectizeGroup.R
@@ -72,7 +72,6 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
           input <- params[[x]]
           tagSelect <- tags$div(
             id = ns(paste0("container-", input$inputId)),
-            style = "width: 100%;",
             selectizeInput(
               inputId = ns(input$inputId),
               label = input$title,

--- a/R/module-selectizeGroup.R
+++ b/R/module-selectizeGroup.R
@@ -70,16 +70,19 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
         X = seq_along(params),
         FUN = function(x) {
           input <- params[[x]]
-          tagSelect <- selectizeInput(
-            inputId = ns(input$inputId),
-            label = input$title,
-            choices = input$choices,
-            selected = input$selected,
-            multiple = ifelse(is.null(input$multiple), TRUE, input$multiple),
-            width = "100%",
-            options = list(
-              placeholder = input$placeholder, plugins = list("remove_button"),
-              onInitialize = I('function() { this.setValue(""); }')
+          tagSelect <- tags$div(
+            id = ns(paste0("container-", input$inputId)),
+            selectizeInput(
+              inputId = ns(input$inputId),
+              label = input$title,
+              choices = input$choices,
+              selected = input$selected,
+              multiple = ifelse(is.null(input$multiple), TRUE, input$multiple),
+              width = "100%",
+              options = list(
+                placeholder = input$placeholder, plugins = list("remove_button"),
+                onInitialize = I('function() { this.setValue(""); }')
+              )
             )
           )
           return(tagSelect)

--- a/R/module-selectizeGroup.R
+++ b/R/module-selectizeGroup.R
@@ -119,6 +119,7 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
 #' @param vars character, columns to use to create filters,
 #'  must correspond to variables listed in \code{params}. Can be a
 #'  \code{reactive} function, but values must be included in the initial ones (in \code{params}).
+#' @param inline If \code{TRUE} (the default), `selectizeInput`s are horizontally positioned, otherwise vertically.
 #'
 #' @export
 #'

--- a/R/module-selectizeGroup.R
+++ b/R/module-selectizeGroup.R
@@ -124,7 +124,7 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
 #'
 #' @rdname selectizeGroup-module
 #' @importFrom shiny updateSelectizeInput observeEvent reactiveValues reactive is.reactive
-selectizeGroupServer <- function(input, output, session, data, vars) { # nocov start
+selectizeGroupServer <- function(input, output, session, data, vars, inline = TRUE) { # nocov start
 
   # Namespace
   ns <- session$ns
@@ -149,7 +149,7 @@ selectizeGroupServer <- function(input, output, session, data, vars) { # nocov s
     for (var in names(rv$data)) {
       if (var %in% rv$vars) {
         toggleDisplayServer(
-          session = session, id = ns(paste0("container-", var)), display = "table-cell"
+          session = session, id = ns(paste0("container-", var)), display = ifelse(inline, "table-cell", "block")
         )
       } else {
         toggleDisplayServer(

--- a/R/module-selectizeGroup.R
+++ b/R/module-selectizeGroup.R
@@ -72,6 +72,7 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
           input <- params[[x]]
           tagSelect <- tags$div(
             id = ns(paste0("container-", input$inputId)),
+            style = "width: 100%;",
             selectizeInput(
               inputId = ns(input$inputId),
               label = input$title,


### PR DESCRIPTION
This wraps the resulting `selectizeInput`s in a container div and adds a inline argument to selectizeGroupServer to switch between "table-cell" and "block" for display.

Accordingly the `inline` argument needs to be repeated in selectizeGroupServer and selectizeGroupUI functions for this to work correctly (I'm wondering if there is a better solution):

```
library(shiny)
library(shinyWidgets)

# ?`selectizeGroup-module`

data("mpg", package = "ggplot2")

ui <- fluidPage(
  fluidRow(
    column(
      width = 10, offset = 1,
      tags$h3("Filter data with selectize group"),
      panel(
        checkboxGroupInput(
          inputId = "vars",
          label = "Variables to use:",
          choices = c("manufacturer", "model", "trans", "class"),
          selected = c("manufacturer", "model", "trans", "class"),
          inline = TRUE
        ),
        selectizeGroupUI(
          id = "my-filters",
          params = list(
            manufacturer = list(inputId = "manufacturer", title = "Manufacturer:"),
            model = list(inputId = "model", title = "Model:"),
            trans = list(inputId = "trans", title = "Trans:"),
            class = list(inputId = "class", title = "Class:")
          ), inline = FALSE
        ),
        status = "primary"
      ),
      DT::dataTableOutput(outputId = "table")
    )
  )
)

server <- function(input, output, session) {
  
  vars_r <- reactive({
    input$vars
  })
  
  res_mod <- callModule(
    module = selectizeGroupServer,
    id = "my-filters",
    data = mpg,
    vars = vars_r,
    inline = FALSE
  )
  
  output$table <- DT::renderDataTable({
    req(res_mod())
    res_mod()
  })
}

shinyApp(ui, server)
```