### PR TITLE
fixes switchInput not starting on ON with value = TRUE

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -278,10 +278,10 @@ html_dependency_bsswitch <- function() {
     bslib::bs_dependency_defer(bsswitchDependencyCSS),
     htmlDependency(
       name = "bootstrap-switch-js",
-      version = "3.4",
+      version = "3.3.4",
       package = "shinyWidgets",
       src = c(href = "shinyWidgets/bootstrap-switch", file = "assets/bootstrap-switch"),
-      script = "bootstrap-switch-3.4/bootstrap-switch.min.js"
+      script = "bootstrap-switch-3.3.4/bootstrap-switch.min.js"
     )
   )
 }
@@ -290,10 +290,10 @@ bsswitchDependencyCSS <- function(theme) {
   if (!bslib::is_bs_theme(theme)) {
     return(htmlDependency(
       name = "bootstrap-switch-css",
-      version = "3.4",
+      version = "3.3.4",
       package = "shinyWidgets",
       src = c(href = "shinyWidgets/bootstrap-switch", file = "assets/bootstrap-switch"),
-      script = "bootstrap-switch-3.4/bootstrap-switch.min.js",
+      script = "bootstrap-switch-3.3.4/bootstrap-switch.min.js",
       stylesheet = "bootstrap-switch-3.4/bootstrap-switch.min.css"
     ))
   }


### PR DESCRIPTION
I don't know how this interfeers with the bslib customization as newly implemented. I would have to read the boostrap-switch code in-depth to validate it. However, this seems to work by usuing bslib themes.

This works as expected:
```R
library(shiny)
library(shinyWidgets) # On #454 

shinyApp(
  fluidPage(switchInput("si", "switchInput", offStatus = "primary"), theme = bslib::bs_theme(primary = "#ff0000")),
  function(input, output, session) {}
)
```