### PR TITLE
fix: add named argument `formula` to `aggregate()`

### DIFF
--- a/R/module-pickerGroup.R
+++ b/R/module-pickerGroup.R
@@ -261,7 +261,7 @@ pickerGroupServer <- function(input, output, session, data, vars) { # nocov star
       X = vars,
       FUN = function(x) {
         tmp <- aggregate(
-          as.formula(paste("indicator", x, sep = "~")),
+          formula = as.formula(paste("indicator", x, sep = "~")),
           data = data,
           FUN = Reduce, f = `|`
         )


### PR DESCRIPTION
To address [#491](https://github.com/dreamRs/shinyWidgets/issues/491).