### PR TITLE
Switch to Font Awesome 6 icon names

### DIFF
--- a/R/input-actiongroupbuttons.R
+++ b/R/input-actiongroupbuttons.R
@@ -26,7 +26,7 @@
 #'     br(),
 #'     actionGroupButtons(
 #'       inputIds = c("btn1", "btn2", "btn3"),
-#'       labels = list("Action 1", "Action 2", tags$span(icon("cog"), "Action 3")),
+#'       labels = list("Action 1", "Action 2", tags$span(icon("gear"), "Action 3")),
 #'       status = "primary"
 #'     ),
 #'     verbatimTextOutput(outputId = "res1"),

--- a/R/input-airDatepicker.R
+++ b/R/input-airDatepicker.R
@@ -197,7 +197,7 @@ airDatepickerInput <- function(inputId,
           tags$div(
             class = "btn action-button input-group-addon",
             id = paste0(inputId, "_button"),
-            icon("calendar")
+            icon("calendar-days")
           )
         },
         tagAir,
@@ -205,7 +205,7 @@ airDatepickerInput <- function(inputId,
           tags$div(
             class = "btn action-button input-group-addon",
             id = paste0(inputId, "_button"),
-            icon("calendar")
+            icon("calendar-days")
           )
         }
       )

--- a/R/input-circlebutton.R
+++ b/R/input-circlebutton.R
@@ -23,7 +23,7 @@
 #'
 #'   ui <- fluidPage(
 #'     tags$h3("Rounded actionBution"),
-#'     circleButton(inputId = "btn1", icon = icon("cog")),
+#'     circleButton(inputId = "btn1", icon = icon("gear")),
 #'     circleButton(
 #'       inputId = "btn2",
 #'       icon = icon("sliders"),

--- a/R/input-dropdown.R
+++ b/R/input-dropdown.R
@@ -55,7 +55,7 @@
 #'       label_on = "NAs keeped",
 #'       label_off = "NAs removed",
 #'       icon_on = icon("check"),
-#'       icon_off = icon("remove")
+#'       icon_off = icon("xmark")
 #'     )
 #'   ),
 #'   tags$div(style = "height: 140px;"), # spacing
@@ -234,7 +234,7 @@ tooltipOptions <- function(placement = "right",
 #'                      label = "Close dropdown"),
 #'         circle = TRUE, status = "danger",
 #'         inputId = "mydropdown",
-#'         icon = icon("cog"), width = "300px"
+#'         icon = icon("gear"), width = "300px"
 #'       )
 #'     ),
 #'     column(

--- a/R/input-icon.R
+++ b/R/input-icon.R
@@ -69,7 +69,7 @@ textInputIcon <- function(inputId,
 #'   textInputIcon(
 #'     inputId = "id",
 #'     label = "With an icon",
-#'     icon = icon("user-circle")
+#'     icon = icon("circle-user")
 #'   ),
 #'   actionButton("updateValue", "Update value"),
 #'   actionButton("updateIcon", "Update icon"),

--- a/R/input-search.R
+++ b/R/input-search.R
@@ -26,8 +26,8 @@
 #'     searchInput(
 #'       inputId = "search", label = "Enter your text",
 #'       placeholder = "A placeholder",
-#'       btnSearch = icon("search"),
-#'       btnReset = icon("remove"),
+#'       btnSearch = icon("magnifying-glass"),
+#'       btnReset = icon("xmark"),
 #'       width = "450px"
 #'     ),
 #'     br(),
@@ -118,8 +118,8 @@ searchInput <- function(inputId, label = NULL, value = "", placeholder = NULL,
 #'   searchInput(
 #'     inputId = "search", label = "Enter your text",
 #'     placeholder = "A placeholder",
-#'     btnSearch = icon("search"),
-#'     btnReset = icon("remove"),
+#'     btnSearch = icon("magnifying-glass"),
+#'     btnReset = icon("xmark"),
 #'     width = "450px"
 #'   ),
 #'   br(),

--- a/R/module-pickerGroup.R
+++ b/R/module-pickerGroup.R
@@ -188,7 +188,7 @@ pickerGroupUI <- function(id, params, label = NULL, btn_label = "Reset filters",
     actionLink(
       inputId = ns("reset_all"),
       label = btn_label,
-      icon = icon("remove"),
+      icon = icon("xmark"),
       style = "float: right;"
     )
   )

--- a/R/module-selectizeGroup.R
+++ b/R/module-selectizeGroup.R
@@ -61,7 +61,7 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
       actionLink(
         inputId = ns("reset_all"),
         label = btn_label,
-        icon = icon("times"),
+        icon = icon("xmark"),
         style = "float: right;"
       )
     )
@@ -94,7 +94,7 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
       actionLink(
         inputId = ns("reset_all"),
         label = btn_label,
-        icon = icon("times"),
+        icon = icon("xmark"),
         style = "float: right;"
       )
     )

--- a/R/sw-dropdown.R
+++ b/R/sw-dropdown.R
@@ -59,7 +59,7 @@
 #'                 value = 3,
 #'                 min = 1, max = 9),
 #'
-#'     style = "unite", icon = icon("cog"),
+#'     style = "unite", icon = icon("gear"),
 #'     status = "danger", width = "300px",
 #'     animate = animateOptions(
 #'       enter = animations$fading_entrances$fadeInLeftBig,
@@ -215,7 +215,7 @@ dropdown <- function(..., style = "default", status = "default",
 #'
 #' dropdown(
 #'  "Your contents goes here ! You can pass several elements",
-#'  circle = TRUE, status = "danger", icon = icon("cog"), width = "300px",
+#'  circle = TRUE, status = "danger", icon = icon("gear"), width = "300px",
 #'  animate = animateOptions(enter = "fadeInDown", exit = "fadeOutUp", duration = 3)
 #' )
 #'

--- a/R/useShinydashboard.R
+++ b/R/useShinydashboard.R
@@ -30,7 +30,7 @@
 #'       "Orders", uiOutput("orderNum2"), "Subtitle", icon = icon("credit-card")
 #'     ),
 #'     infoBox(
-#'       "Approval Rating", "60%", icon = icon("line-chart"), color = "green",
+#'       "Approval Rating", "60%", icon = icon("chart-line"), color = "green",
 #'       fill = TRUE
 #'     ),
 #'     infoBox(
@@ -46,7 +46,7 @@
 #'     ),
 #'     valueBox(
 #'       tagList("60", tags$sup(style="font-size: 20px", "%")),
-#'       "Approval Rating", icon = icon("line-chart"), color = "green"
+#'       "Approval Rating", icon = icon("chart-line"), color = "green"
 #'     ),
 #'     valueBox(
 #'       htmlOutput("progress"), "Progress", icon = icon("users"), color = "purple"

--- a/R/useShinydashboardPlus.R
+++ b/R/useShinydashboardPlus.R
@@ -41,7 +41,7 @@
 #'      boxDropdownItem("Link to google", href = "http://www.google.com"),
 #'      boxDropdownItem("item 2", href = "#"),
 #'      dropdownDivider(),
-#'      boxDropdownItem("item 3", href = "#", icon = icon("th"))
+#'      boxDropdownItem("item 3", href = "#", icon = icon("table-cells"))
 #'    ),
 #'    sidebar = boxSidebar(
 #'      startOpen = TRUE,

--- a/R/vertical-tab.R
+++ b/R/vertical-tab.R
@@ -171,7 +171,7 @@ verticalTabPanel <- function(title, ..., value = title, icon = NULL, box_height 
 #'       verticalTabsetPanel(
 #'         id = "TABS",
 #'         verticalTabPanel(
-#'           title = "Title 1", icon = icon("home", "fa-2x"),
+#'           title = "Title 1", icon = icon("house", "fa-2x"),
 #'           "Content panel 1"
 #'         ),
 #'         verticalTabPanel(

--- a/examples/checkboxGroupButtons.R
+++ b/examples/checkboxGroupButtons.R
@@ -24,7 +24,7 @@ ui <- fluidPage(
     label = "With icons:",
     choices = names(mtcars),
     checkIcon = list(
-      yes = icon("check-square"),
+      yes = icon("square-check"),
       no = icon("square-o")
     )
   ),

--- a/examples/checkboxGroupButtons.R
+++ b/examples/checkboxGroupButtons.R
@@ -25,7 +25,7 @@ ui <- fluidPage(
     choices = names(mtcars),
     checkIcon = list(
       yes = icon("square-check"),
-      no = icon("square-o")
+      no = icon("square")
     )
   ),
   verbatimTextOutput("value3")

--- a/examples/disable-buttons.R
+++ b/examples/disable-buttons.R
@@ -15,7 +15,7 @@ ui <- fluidPage(
     label = "Radio buttons",
     checkIcon = list(
       yes = icon("square-check"),
-      no = icon("square-o")
+      no = icon("square")
     )
   ),
 

--- a/examples/disable-buttons.R
+++ b/examples/disable-buttons.R
@@ -14,7 +14,7 @@ ui <- fluidPage(
     choices = setNames(1:6, head(month.name)),
     label = "Radio buttons",
     checkIcon = list(
-      yes = icon("check-square"),
+      yes = icon("square-check"),
       no = icon("square-o")
     )
   ),

--- a/examples/ex-stati-card.R
+++ b/examples/ex-stati-card.R
@@ -9,7 +9,7 @@ ui <- fluidPage(
   fluidRow(
     column(
       width = 3,
-      statiCard(12, "Subtitle", icon("home")),
+      statiCard(12, "Subtitle", icon("house")),
       statiCard(
         93, "Animated card", icon("users"),
         background = "deepskyblue",
@@ -35,7 +35,7 @@ ui <- fluidPage(
     ),
     column(
       width = 3,
-      statiCard(12, "No animation", icon("home"), color = "firebrick")
+      statiCard(12, "No animation", icon("house"), color = "firebrick")
     ),
     column(
       width = 3,
@@ -50,13 +50,13 @@ ui <- fluidPage(
       statiCard(
         "123456 something very very long",
         "Long value text with icon",
-        icon = icon("tachometer-alt"),
+        icon = icon("gauge"),
         left = TRUE
       ),
       statiCard(
         "123456 something very very long",
         "Long value text with icon right",
-        icon = icon("tasks")
+        icon = icon("list-check")
       )
     )
   )
@@ -85,7 +85,7 @@ server <- function(input, output, session) {
     statiCard(
       format(sample.int(1e6, 1), big.mark = " "),
       "Total spend",
-      icon("shopping-cart"),
+      icon("cart-shopping"),
       left = TRUE,
       animate = TRUE
     )

--- a/examples/prettyToggle.R
+++ b/examples/prettyToggle.R
@@ -30,7 +30,7 @@ ui <- fluidPage(
         inputId = "toggle2",
         label_on = "Yes!", icon_on = icon("check"),
         status_on = "info", status_off = "warning",
-        label_off = "No..", icon_off = icon("remove")
+        label_off = "No..", icon_off = icon("xmark")
       ),
       verbatimTextOutput(outputId = "res2")
     ),
@@ -89,7 +89,7 @@ ui <- fluidPage(
     inputId = "toggle3",
     label_on = "",
     label_off = "",
-    icon_on = icon("volume-up", lib = "glyphicon"),
+    icon_on = icon("volume-high", lib = "glyphicon"),
     icon_off = icon("volume-off", lib = "glyphicon"),
     status_on = "primary",
     status_off = "default",

--- a/examples/radioGroupButtons.R
+++ b/examples/radioGroupButtons.R
@@ -24,7 +24,7 @@ ui <- fluidPage(
     label = "With icons:",
     choices = names(mtcars),
     checkIcon = list(
-      yes = icon("check-square"),
+      yes = icon("square-check"),
       no = icon("square-o")
     )
   ),

--- a/examples/radioGroupButtons.R
+++ b/examples/radioGroupButtons.R
@@ -25,7 +25,7 @@ ui <- fluidPage(
     choices = names(mtcars),
     checkIcon = list(
       yes = icon("square-check"),
-      no = icon("square-o")
+      no = icon("square")
     )
   ),
   verbatimTextOutput("value3")

--- a/examples/show_alert.R
+++ b/examples/show_alert.R
@@ -11,7 +11,7 @@ ui <- fluidPage(
   actionButton(
     inputId = "error",
     label = "Launch an error sweet alert",
-    icon = icon("remove")
+    icon = icon("xmark")
   ),
   actionButton(
     inputId = "sw_html",

--- a/examples/show_toast.R
+++ b/examples/show_toast.R
@@ -16,12 +16,12 @@ ui <- fluidPage(
   actionButton(
     inputId = "error",
     label = "Show error toast",
-    icon = icon("remove")
+    icon = icon("xmark")
   ),
   actionButton(
     inputId = "warning",
     label = "Show warning toast",
-    icon = icon("exclamation-triangle")
+    icon = icon("triangle-exclamation")
   ),
   actionButton(
     inputId = "info",

--- a/examples/textInputIcon.R
+++ b/examples/textInputIcon.R
@@ -12,13 +12,13 @@ ui <- fluidPage(
       textInputIcon(
         inputId = "ex1",
         label = "With an icon",
-        icon = icon("user-circle")
+        icon = icon("circle-user")
       ),
       verbatimTextOutput("res1"),
       textInputIcon(
         inputId = "ex2",
         label = "With an icon (right)",
-        icon = list(NULL, icon("user-circle"))
+        icon = list(NULL, icon("circle-user"))
       ),
       verbatimTextOutput("res2"),
       textInputIcon(

--- a/examples/updatePrettyCheckboxGroup.R
+++ b/examples/updatePrettyCheckboxGroup.R
@@ -13,7 +13,7 @@ ui <- fluidPage(
         label = "Update my value!",
         choices = month.name[1:4],
         status = "danger",
-        icon = icon("remove")
+        icon = icon("xmark")
       ),
       verbatimTextOutput(outputId = "res1"),
       br(),

--- a/examples/updatePrettyRadioButtons.R
+++ b/examples/updatePrettyRadioButtons.R
@@ -13,7 +13,7 @@ ui <- fluidPage(
         label = "Update my value!",
         choices = month.name[1:4],
         status = "danger",
-        icon = icon("remove")
+        icon = icon("xmark")
       ),
       verbatimTextOutput(outputId = "res1"),
       br(),

--- a/examples/useSweetAlert.R
+++ b/examples/useSweetAlert.R
@@ -16,7 +16,7 @@ if (interactive()) {
     actionButton(
       inputId = "error",
       label = "Launch an error sweet alert",
-      icon = icon("remove")
+      icon = icon("xmark")
     ),
     actionButton(
       inputId = "sw_html",

--- a/examples/vertical-tab.R
+++ b/examples/vertical-tab.R
@@ -13,7 +13,7 @@ ui <- fluidPage(
         id = "my_vertical_tab_panel",
         verticalTabPanel(
           title = "Title 1",
-          icon = icon("home", "fa-2x"),
+          icon = icon("house", "fa-2x"),
           "Content panel 1"
         ),
         verticalTabPanel(

--- a/inst/examples/checkboxGroupButtons/ui.R
+++ b/inst/examples/checkboxGroupButtons/ui.R
@@ -157,7 +157,7 @@ fluidPage(
         choices = c("Choice 1", "Choice 2", "Choice 3"),
         checkIcon = list(
           yes = icon("check"),
-          no = icon("times")
+          no = icon("xmark")
         )
       ),
       verbatimTextOutput(outputId = "res13")

--- a/inst/examples/dropdown/ex-sw-dropdown.R
+++ b/inst/examples/dropdown/ex-sw-dropdown.R
@@ -11,7 +11,7 @@ ui <- fluidPage(
     shinyWidgets::pickerInput(inputId = 'xcol', label = 'X Variable', choices = names(iris)),
     selectInput(inputId = 'ycol', label = 'Y Variable', choices = names(iris), selected = names(iris)[[2]]),
     sliderInput(inputId = 'clusters', label = 'Cluster count', value = 3, min = 1, max = 9),
-    style = "material-circle", icon = icon("cog"), status = "danger",
+    style = "material-circle", icon = icon("gear"), status = "danger",
     animate = animateOptions(enter = animations$zooming_entrances$zoomInDown, exit = animations$zooming_exits$zoomOutUp, duration = 1)
   ),
   plotOutput(outputId = 'plot1')

--- a/inst/examples/radioGroupButtons/ui.R
+++ b/inst/examples/radioGroupButtons/ui.R
@@ -134,7 +134,7 @@ fluidPage(
         choices = c("Choice 1", "Choice 2", "Choice 3"),
         checkIcon = list(
           yes = icon("check"),
-          no = icon("times")
+          no = icon("xmark")
         )
       ),
       verbatimTextOutput(outputId = "res13")

--- a/inst/examples/shinyWidgets/code_dropdown.R
+++ b/inst/examples/shinyWidgets/code_dropdown.R
@@ -24,7 +24,7 @@ ui <- fluidPage(
                 value = 3,
                 min = 1, max = 9),
 
-    style = "unite", icon = icon("cog"),
+    style = "unite", icon = icon("gear"),
     status = "danger", width = "300px",
     animate = animateOptions(
       enter = animations$fading_entrances$fadeInLeftBig,

--- a/inst/examples/shinyWidgets/code_dropdownButton.R
+++ b/inst/examples/shinyWidgets/code_dropdownButton.R
@@ -24,7 +24,7 @@ ui <- fluidPage(
                 max = 9),
 
     circle = TRUE, status = "danger",
-    icon = icon("cog"), width = "300px",
+    icon = icon("gear"), width = "300px",
 
     tooltip = tooltipOptions(title = "Click to see inputs !")
   ),

--- a/inst/examples/shinyWidgets/ui.R
+++ b/inst/examples/shinyWidgets/ui.R
@@ -50,18 +50,18 @@ header <- dashboardHeader(title = "shinyWidgets gallery")
 sidebar <- dashboardSidebar(
   sidebarMenu(
     id = "tabs",
-    menuItem(text = "Overview", tabName = "tabOverview", icon = icon("th")),
+    menuItem(text = "Overview", tabName = "tabOverview", icon = icon("table-cells")),
     menuItem(text = "switchInput", tabName = "tabswitchInput", icon = icon("toggle-on")),
-    menuItem(text = "Pretty Checkboxes & Radios", tabName = "tabPretty", icon = icon("check-circle")),
-    menuItem(text = "Awesome Checkboxes & Radios", tabName = "tabAwesome", icon = icon("check-square")),
+    menuItem(text = "Pretty Checkboxes & Radios", tabName = "tabPretty", icon = icon("circle-check")),
+    menuItem(text = "Awesome Checkboxes & Radios", tabName = "tabAwesome", icon = icon("square-check")),
     menuItem(text = "checkboxGroup Buttons", tabName = "tabcheckButtons", icon = icon("square")),
     menuItem(text = "radio Buttons", tabName = "tabradioButtons", icon = icon("circle")),
     menuItem(text = "materialSwitch", tabName = "tabMaterialSwitch", icon = icon("toggle-off")),
     menuItem(text = "pickerInput", tabName = "tabPickerInput", icon = icon("caret-down")),
-    menuItem(text = "sliderText", tabName = "tabSliderText", icon = icon("sliders-h")),
-    menuItem(text = "progressBar", tabName = "tabProgressBars", icon = icon("tasks")),
+    menuItem(text = "sliderText", tabName = "tabSliderText", icon = icon("sliders")),
+    menuItem(text = "progressBar", tabName = "tabProgressBars", icon = icon("list-check")),
     menuItem(text = "bttn", tabName = "tabBttn", icon = icon("square")),
-    menuItem(text = "dropdowns & sweetalert", tabName = "tabOtherStuff", icon = icon("plus-circle"))
+    menuItem(text = "dropdowns & sweetalert", tabName = "tabOtherStuff", icon = icon("circle-plus"))
   )
 )
 
@@ -180,8 +180,8 @@ body <- dashboardBody(
               args = list(
                 inputId = ID(.shinyWidgetGalleryId), label = "Click search icon to update or hit 'Enter'",
                 placeholder = "A placeholder",
-                btnSearch = icon("search"),
-                btnReset = icon("times"),
+                btnSearch = icon("magnifying-glass"),
+                btnReset = icon("xmark"),
                 width = "100%"
               )
             )
@@ -431,7 +431,7 @@ body <- dashboardBody(
               args = list(inputId = ID(.shinyWidgetGalleryId),
                           label_on = "Yes!", icon_on = icon("check"),
                           status_on = "info", status_off = "warning",
-                          label_off = "No..", icon_off = icon("times"))
+                          label_off = "No..", icon_off = icon("xmark"))
             )
           )
           ,
@@ -483,7 +483,7 @@ body <- dashboardBody(
             .shinyWidgetGalleryFuns$widget_wrapper(
               fun = prettyCheckboxGroup,
               args = list(inputId = ID(.shinyWidgetGalleryId), label = "Choose:", choices = c("Click me !", "Me !", "Or me !"),
-                          icon = icon("check-square"), status = "primary", outline = TRUE, animation = "jelly")
+                          icon = icon("square-check"), status = "primary", outline = TRUE, animation = "jelly")
             )
           )
           ,
@@ -774,7 +774,7 @@ body <- dashboardBody(
               fun = checkboxGroupButtons,
               args = list(
                 inputId = ID(.shinyWidgetGalleryId), label = "Label", choices = c("A", "B", "C", "D"), status = "primary",
-                checkIcon = list(yes = icon("ok", lib = "glyphicon"), no = icon("remove", lib = "glyphicon"))
+                checkIcon = list(yes = icon("ok", lib = "glyphicon"), no = icon("xmark", lib = "glyphicon"))
               )
             )
           )
@@ -926,7 +926,7 @@ body <- dashboardBody(
               fun = radioGroupButtons,
               args = list(
                 inputId = ID(.shinyWidgetGalleryId), label = "Label", choices = c("A", "B", "C", "D"), status = "primary",
-                checkIcon = list(yes = icon("ok", lib = "glyphicon"), no = icon("remove", lib = "glyphicon"))
+                checkIcon = list(yes = icon("ok", lib = "glyphicon"), no = icon("xmark", lib = "glyphicon"))
               )
             )
           )
@@ -1569,7 +1569,7 @@ body <- dashboardBody(
             title = NULL,
             .shinyWidgetGalleryFuns$widget_wrapper(
               fun = actionBttn,
-              args = list(inputId = ID(.shinyWidgetGalleryId), label = "bordered", style = "bordered", color = "success", icon = icon("sliders-h"))
+              args = list(inputId = ID(.shinyWidgetGalleryId), label = "bordered", style = "bordered", color = "success", icon = icon("sliders"))
             ),
             footer = NULL
           ),
@@ -1630,7 +1630,7 @@ body <- dashboardBody(
               selectInput(inputId = 'xcol', label = 'X Variable', choices = names(iris)),
               selectInput(inputId = 'ycol', label = 'Y Variable', choices = names(iris), selected = names(iris)[[2]]),
               sliderInput(inputId = 'clusters', label = 'Cluster count', value = 3, min = 1, max = 9),
-              circle = TRUE, status = "danger", icon = icon("cog"), width = "300px",
+              circle = TRUE, status = "danger", icon = icon("gear"), width = "300px",
               tooltip = tooltipOptions(title = "Click to see inputs !")
             ),
             plotOutput(outputId = 'plot1'),
@@ -1652,7 +1652,7 @@ body <- dashboardBody(
               pickerInput(inputId = 'xcol2', label = 'X Variable', choices = names(iris), options = list(`style` = "btn-info")),
               pickerInput(inputId = 'ycol2', label = 'Y Variable', choices = names(iris), selected = names(iris)[[2]], options = list(`style` = "btn-warning")),
               sliderInput(inputId = 'clusters2', label = 'Cluster count', value = 3, min = 1, max = 9),
-              style = "unite", icon = icon("cog"), status = "danger", width = "300px",
+              style = "unite", icon = icon("gear"), status = "danger", width = "300px",
               animate = animateOptions(enter = animations$fading_entrances$fadeInLeftBig, exit = animations$fading_exits$fadeOutRightBig)
             ),
             plotOutput(outputId = 'plot2'),

--- a/tests/testthat/test-bsplus.R
+++ b/tests/testthat/test-bsplus.R
@@ -31,8 +31,8 @@ test_that("Search Input", {
   tag_searchInput <- searchInput(
     inputId = "search", label = "Enter your text",
     placeholder = "A placeholder",
-    btnSearch = shiny::icon("search"),
-    btnReset = shiny::icon("remove"),
+    btnSearch = shiny::icon("magnifying-glass"),
+    btnReset = shiny::icon("xmark"),
     width = "450px"
   )
 

--- a/tests/testthat/test-checkboxGroupButtons.R
+++ b/tests/testthat/test-checkboxGroupButtons.R
@@ -144,15 +144,15 @@ test_that("Icons button", {
     inputId = "Id036",
     label = "Choose a graph :",
     choiceNames = list(
-      shiny::icon("cog"),
-      shiny::icon("cogs")
+      shiny::icon("gear"),
+      shiny::icon("gears")
     ),
     choiceValues = c("A", "B"),
     justified = TRUE
   )
   cbtag <- as.character(cbtag)
-  expect_true(grepl(pattern = as.character(shiny::icon("cog")), x = cbtag))
-  expect_true(grepl(pattern = as.character(shiny::icon("cogs")), x = cbtag))
+  expect_true(grepl(pattern = as.character(shiny::icon("gear")), x = cbtag))
+  expect_true(grepl(pattern = as.character(shiny::icon("gears")), x = cbtag))
 })
 
 
@@ -178,7 +178,7 @@ test_that("Icons check / uncheck", {
     label = "Label", choices = c("A", "B", "C", "D"),
     status = "primary",
     checkIcon = list(yes = shiny::icon("ok", lib = "glyphicon"),
-                     no = shiny::icon("remove", lib = "glyphicon"))
+                     no = shiny::icon("xmark", lib = "glyphicon"))
   )
   cbtag <- as.character(cbtag)
   expect_true(grepl(pattern = "check-btn-icon-no", x = cbtag))

--- a/tests/testthat/test-dropdown.R
+++ b/tests/testthat/test-dropdown.R
@@ -6,7 +6,7 @@ test_that("Default", {
 
   tagdrop <- dropdown(
     "Content goes here",
-    style = "unite", icon = shiny::icon("cog"), status = "danger", width = "300px",
+    style = "unite", icon = shiny::icon("gear"), status = "danger", width = "300px",
     animate = animateOptions(
       enter = animations$fading_entrances$fadeInLeftBig,
       exit = animations$fading_exits$fadeOutRightBig
@@ -20,7 +20,7 @@ test_that("inputId", {
 
   tagdrop <- dropdown(
     "Content goes here",
-    style = "default", icon = shiny::icon("cog"), status = "danger", width = "300px",
+    style = "default", icon = shiny::icon("gear"), status = "danger", width = "300px",
     inputId = "MYID"
   )
   expect_identical(tagdrop$attribs$id, "sw-drop-MYID")

--- a/tests/testthat/test-dropdownButton.R
+++ b/tests/testthat/test-dropdownButton.R
@@ -6,7 +6,7 @@ test_that("Default", {
 
   tagdropBtn <- dropdownButton(
     "Your contents goes here ! You can pass several elements",
-    circle = TRUE, status = "danger", icon = shiny::icon("cog"), width = "300px",
+    circle = TRUE, status = "danger", icon = shiny::icon("gear"), width = "300px",
     tooltip = tooltipOptions(title = "Click to see inputs !")
   )
 
@@ -18,7 +18,7 @@ test_that("InputId", {
 
   tagdropBtn <- dropdownButton(
     "Your contents goes here ! You can pass several elements", inputId = "MYID",
-    circle = FALSE, status = "danger", icon = shiny::icon("cog"), width = "300px"
+    circle = FALSE, status = "danger", icon = shiny::icon("gear"), width = "300px"
   )
 
   expect_identical(tagdropBtn$attribs$id, "MYID_state")

--- a/tests/testthat/test-input-icon.R
+++ b/tests/testthat/test-input-icon.R
@@ -7,7 +7,7 @@ test_that("textInputIcon works", {
   tag <- textInputIcon(
     inputId = "ID",
     label = "With an icon",
-    icon = shiny::icon("user-circle-o")
+    icon = shiny::icon("circle-user")
   )
 
   expect_is(tag, "shiny.tag")
@@ -36,7 +36,7 @@ test_that("textInputIcon works", {
     inputId = "ID",
     label = "With an icon",
     value = 0,
-    icon = shiny::icon("user-circle-o")
+    icon = shiny::icon("circle-user")
   )
 
   expect_is(tag, "shiny.tag")

--- a/tests/testthat/test-radioGroupButtons.R
+++ b/tests/testthat/test-radioGroupButtons.R
@@ -144,15 +144,15 @@ test_that("Icons button", {
     inputId = "Id036",
     label = "Choose a graph :",
     choiceNames = list(
-      shiny::icon("cog"),
-      shiny::icon("cogs")
+      shiny::icon("gear"),
+      shiny::icon("gears")
     ),
     choiceValues = c("A", "B"),
     justified = TRUE
   )
   rtag <- as.character(rtag)
-  expect_true(grepl(pattern = as.character(shiny::icon("cog")), x = rtag))
-  expect_true(grepl(pattern = as.character(shiny::icon("cogs")), x = rtag))
+  expect_true(grepl(pattern = as.character(shiny::icon("gear")), x = rtag))
+  expect_true(grepl(pattern = as.character(shiny::icon("gears")), x = rtag))
 })
 
 
@@ -178,7 +178,7 @@ test_that("Icons check / uncheck", {
     label = "Label", choices = c("A", "B", "C", "D"),
     status = "primary",
     checkIcon = list(yes = shiny::icon("ok", lib = "glyphicon"),
-                     no = shiny::icon("remove", lib = "glyphicon"))
+                     no = shiny::icon("xmark", lib = "glyphicon"))
   )
   rtag <- as.character(rtag)
   expect_true(grepl(pattern = "radio-btn-icon-no", x = rtag))

--- a/tests/testthat/test-vertical-tab.R
+++ b/tests/testthat/test-vertical-tab.R
@@ -5,7 +5,7 @@ test_that("verticalTabPanel works", {
 
   tag <- verticalTabsetPanel(
     verticalTabPanel(
-      title = "Title 1", icon = shiny::icon("home", "fa-2x"),
+      title = "Title 1", icon = shiny::icon("house", "fa-2x"),
       "Content panel 1"
     ),
     verticalTabPanel(
@@ -30,7 +30,7 @@ test_that("verticalTabPanel (with args) works", {
     menuSide = "right",
     selected = "Title 2",
     verticalTabPanel(
-      title = "Title 1", icon = shiny::icon("home", "fa-2x"),
+      title = "Title 1", icon = shiny::icon("house", "fa-2x"),
       "Content panel 1"
     ),
     verticalTabPanel(


### PR DESCRIPTION
Update needed due to: https://github.com/rstudio/fontawesome/blob/main/NEWS.md#fontawesome-030

Since this is too much work manually, I'm using the html tables provided here: https://fontawesome.com/docs/web/setup/upgrade/upgrade-from-v4#icons-renamed-since-version-4
https://fontawesome.com/docs/web/setup/upgrade/whats-changed#icons-renamed-in-version-6
and replaced the names in the files:

```
library(fs)
library(rvest)
library(stringi)
library(data.table)

html_table_v4_to_v6 <- read_html("https://fontawesome.com/docs/web/setup/upgrade/upgrade-from-v4#icons-renamed-since-version-4")
html_table_v5_to_v6 <- read_html("https://fontawesome.com/docs/web/setup/upgrade/whats-changed#icons-renamed-in-version-6")

mapping_dt_v4_to_v6 <- as.data.table(html_table(html_table_v4_to_v6)[[2]])[, c("New Icon Prefix", "Unicode Value", "Icon Details") := NULL]
setnames(mapping_dt_v4_to_v6, new = c("old_name", "new_name"))

mapping_dt_v5_to_v6 <- as.data.table(html_table(html_table_v5_to_v6)[[3]])[, "Icon Details" := NULL]
setnames(mapping_dt_v5_to_v6, new = c("old_name", "new_name"))

mapping_dt <- unique(rbindlist(list(mapping_dt_v4_to_v6, mapping_dt_v5_to_v6))[old_name != new_name])

# Please insert the output of dput(mapping_dt) here if needed (see below)
# mapping_dt <- structure(< ... >)

mapping_dt[, c("old_icon_call", "new_icon_call") := lapply(.SD, function(x){paste0("icon(\"", x, "\"")}), .SDcols = c("old_name", "new_name")]

r_scripts <- dir_ls(
  path = "./shinyWidgets",
  recurse = TRUE,
  type = "file",
  glob = "*.R",
)

for (r_script in r_scripts){
  content <- stringi::stri_read_lines(r_script)
  updated_content <- stri_replace_all_fixed(content, pattern = mapping_dt$old_icon_call, replacement = mapping_dt$new_icon_call, vectorize_all = FALSE)
  stringi::stri_write_lines(str = updated_content, con = r_script, sep = "\n")
}


# backup mapping table ----------------------------------------------------
# dput(mapping_dt)

# mapping_dt <- structure( list( old_name = c( "address-book-o",
# "address-card-o", "area-chart", "arrow-circle-o-down", "arrow-circle-o-left",
# "arrow-circle-o-right", "arrow-circle-o-up", "arrows", "arrows-alt",
# "arrows-h", "arrows-v", "asl-interpreting", "automobile", "bar-chart",
# "bar-chart-o", "bathtub", "battery", "battery-0", "battery-1", "battery-2",
# "battery-3", "battery-4", "bell-o", "bell-slash-o", "bitbucket-square",
# "bitcoin", "bookmark-o", "building-o", "cab", "calendar", "calendar-check-o",
# "calendar-minus-o", "calendar-o", "calendar-plus-o", "calendar-times-o",
# "caret-square-o-down", "caret-square-o-left", "caret-square-o-right",
# "caret-square-o-up", "cc", "chain", "chain-broken", "check-circle-o",
# "check-square-o", "circle-o", "circle-o-notch", "circle-thin", "clock-o",
# "close", "cloud-download", "cloud-upload", "cny", "code-fork", "comment-o",
# "commenting", "commenting-o", "comments-o", "compress", "credit-card-alt",
# "cutlery", "dashboard", "deafness", "dedent", "diamond", "dollar",
# "dot-circle-o", "drivers-license", "drivers-license-o", "eercast",
# "envelope-o", "envelope-open-o", "eur", "euro", "exchange", "expand",
# "external-link", "external-link-square", "eyedropper", "fa", "facebook",
# "facebook-official", "feed", "file-archive-o", "file-audio-o", "file-code-o",
# "file-excel-o", "file-image-o", "file-movie-o", "file-o", "file-pdf-o",
# "file-photo-o", "file-picture-o", "file-powerpoint-o", "file-sound-o",
# "file-text", "file-text-o", "file-video-o", "file-word-o", "file-zip-o",
# "files-o", "flag-o", "flash", "floppy-o", "folder-o", "folder-open-o",
# "frown-o", "futbol-o", "gbp", "ge", "gittip", "glass", "google-plus",
# "google-plus-circle", "google-plus-official", "group", "hand-grab-o",
# "hand-lizard-o", "hand-o-down", "hand-o-left", "hand-o-right", "hand-o-up",
# "hand-paper-o", "hand-peace-o", "hand-pointer-o", "hand-rock-o",
# "hand-scissors-o", "hand-spock-o", "hand-stop-o", "handshake-o",
# "hard-of-hearing", "hdd-o", "header", "heart-o", "hospital-o", "hotel",
# "hourglass-1", "hourglass-2", "hourglass-3", "hourglass-o", "id-card-o",
# "ils", "inr", "institution", "intersex", "jpy", "keyboard-o", "krw", "legal",
# "lemon-o", "level-down", "level-up", "life-bouy", "life-buoy", "life-saver",
# "lightbulb-o", "line-chart", "linkedin", "linkedin-square", "list-alt",
# "long-arrow-down", "long-arrow-left", "long-arrow-right", "long-arrow-up",
# "mail-forward", "mail-reply", "mail-reply-all", "map-marker", "map-o",
# "meanpath", "meh-o", "minus-square-o", "mobile", "mobile-phone", "money",
# "moon-o", "mortar-board", "navicon", "newspaper-o", "paper-plane-o", "paste",
# "pause-circle-o", "pencil-square", "pencil-square-o", "photo", "picture-o",
# "pie-chart", "play-circle-o", "plus-square-o", "question-circle-o", "ra",
# "refresh", "remove", "reorder", "repeat", "resistance", "rmb", "rotate-left",
# "rotate-right", "rouble", "rub", "ruble", "rupee", "s15", "send", "send-o",
# "share-square-o", "shekel", "sheqel", "shield", "sign-in", "sign-out",
# "signing", "smile-o", "snapchat-ghost", "snowflake-o", "soccer-ball-o",
# "sort-alpha-asc", "sort-alpha-desc", "sort-amount-asc", "sort-amount-desc",
# "sort-asc", "sort-desc", "sort-numeric-asc", "sort-numeric-desc", "square-o",
# "star-half-empty", "star-half-full", "star-half-o", "star-o", "sticky-note-o",
# "stop-circle-o", "sun-o", "support", "tablet", "tachometer", "television",
# "thermometer", "thermometer-0", "thermometer-1", "thermometer-2",
# "thermometer-3", "thermometer-4", "thumb-tack", "thumbs-o-down",
# "thumbs-o-up", "ticket", "times-circle-o", "times-rectangle",
# "times-rectangle-o", "toggle-down", "toggle-left", "toggle-right",
# "toggle-up", "trash", "trash-o", "try", "turkish-lira", "unsorted", "usd",
# "user-circle-o", "user-o", "vcard", "vcard-o", "video-camera", "vimeo",
# "volume-control-phone", "warning", "wechat", "wheelchair-alt",
# "window-close-o", "won", "y-combinator-square", "yc", "yc-square", "yen",
# "youtube-play", "ad", "adjust", "air-freshener", "alien-monster", "allergies",
# "ambulance", "american-sign-language-interpreting", "analytics",
# "angle-double-down", "angle-double-left", "angle-double-right",
# "angle-double-up", "angry", "apple-alt", "apple-crate", "archive",
# "arrow-alt-circle-down", "arrow-alt-circle-left", "arrow-alt-circle-right",
# "arrow-alt-circle-up", "arrow-alt-down", "arrow-alt-from-bottom",
# "arrow-alt-from-left", "arrow-alt-from-right", "arrow-alt-from-top",
# "arrow-alt-left", "arrow-alt-right", "arrow-alt-square-down",
# "arrow-alt-square-left", "arrow-alt-square-right", "arrow-alt-square-up",
# "arrow-alt-to-bottom", "arrow-alt-to-left", "arrow-alt-to-right",
# "arrow-alt-to-top", "arrow-alt-up", "arrow-circle-down", "arrow-circle-left",
# "arrow-circle-right", "arrow-circle-up", "arrow-from-bottom",
# "arrow-from-left", "arrow-from-right", "arrow-from-top", "arrow-square-down",
# "arrow-square-left", "arrow-square-right", "arrow-square-up",
# "arrow-to-bottom", "arrow-to-left", "arrow-to-right", "arrow-to-top",
# "arrows", "arrows-alt", "arrows-alt-h", "arrows-alt-v", "arrows-h",
# "arrows-v", "assistive-listening-systems", "atlas", "atom-alt", "backspace",
# "balance-scale", "balance-scale-left", "balance-scale-right", "band-aid",
# "barcode-alt", "baseball-ball", "basketball-ball", "bed-alt", "beer",
# "betamax", "bible", "biking", "biking-mountain", "birthday-cake", "blind",
# "book-alt", "book-dead", "book-reader", "book-spells", "border-style",
# "border-style-alt", "box-alt", "box-fragile", "box-full", "box-up", "box-usd",
# "boxes", "boxes-alt", "brackets", "broadcast-tower", "burn", "bus-alt",
# "calculator-alt", "calendar-alt", "calendar-edit", "calendar-times",
# "camera-alt", "camera-home", "car-alt", "car-crash", "car-mechanic",
# "caravan-alt", "caret-circle-down", "caret-circle-left", "caret-circle-right",
# "caret-circle-up", "caret-square-down", "caret-square-left",
# "caret-square-right", "caret-square-up", "cctv", "chalkboard-teacher",
# "chart-pie-alt", "check-circle", "check-square", "cheeseburger",
# "chess-bishop-alt", "chess-clock-alt", "chess-king-alt", "chess-knight-alt",
# "chess-pawn-alt", "chess-queen-alt", "chess-rook-alt", "chevron-circle-down",
# "chevron-circle-left", "chevron-circle-right", "chevron-circle-up",
# "chevron-double-down", "chevron-double-left", "chevron-double-right",
# "chevron-double-up", "chevron-square-down", "chevron-square-left",
# "chevron-square-right", "chevron-square-up", "clinic-medical",
# "cloud-download-alt", "cloud-upload-alt", "cocktail", "coffee", "coffee-togo",
# "cog", "cogs", "columns", "comment-alt", "comment-alt-check",
# "comment-alt-dollar", "comment-alt-dots", "comment-alt-edit",
# "comment-alt-exclamation", "comment-alt-lines", "comment-alt-medical",
# "comment-alt-minus", "comment-alt-music", "comment-alt-plus",
# "comment-alt-slash", "comment-alt-smile", "comment-alt-times", "comment-edit",
# "comment-times", "comments-alt", "comments-alt-dollar", "compress-alt",
# "compress-arrows-alt", "concierge-bell", "construction", "conveyor-belt-alt",
# "cowbell-more", "cricket", "crop-alt", "curling", "cut", "deaf", "debug",
# "desktop-alt", "dewpoint", "diagnoses", "digging", "digital-tachograph",
# "directions", "dizzy", "dolly-flatbed", "dolly-flatbed-alt",
# "dolly-flatbed-empty", "donate", "dot-circle", "drafting-compass",
# "drone-alt", "dryer-alt", "eclipse-alt", "edit", "ellipsis-h",
# "ellipsis-h-alt", "ellipsis-v", "ellipsis-v-alt", "envelope-square",
# "exchange", "exchange-alt", "exclamation-circle", "exclamation-square",
# "exclamation-triangle", "expand-alt", "expand-arrows", "expand-arrows-alt",
# "external-link", "external-link-alt", "external-link-square",
# "external-link-square-alt", "fast-backward", "fast-forward", "feather-alt",
# "female", "field-hockey", "fighter-jet", "file-alt", "file-archive",
# "file-chart-line", "file-download", "file-edit", "file-medical-alt",
# "file-search", "file-times", "file-upload", "film-alt", "fire-alt",
# "first-aid", "fist-raised", "flag-alt", "flame", "flask-poison",
# "flask-potion", "flushed", "fog", "folder-download", "folder-times",
# "folder-upload", "font-awesome-alt", "font-awesome-flag",
# "font-awesome-logo-full", "football-ball", "fragile", "frosty-head", "frown",
# "frown-open", "funnel-dollar", "game-board-alt", "gamepad-alt",
# "glass-champagne", "glass-cheers", "glass-martini", "glass-martini-alt",
# "glass-whiskey", "glass-whiskey-rocks", "glasses-alt", "globe-africa",
# "globe-americas", "globe-asia", "globe-europe", "golf-ball", "grimace",
# "grin", "grin-alt", "grin-beam", "grin-beam-sweat", "grin-hearts",
# "grin-squint", "grin-squint-tears", "grin-stars", "grin-tears", "grin-tongue",
# "grin-tongue-squint", "grin-tongue-wink", "grin-wink", "grip-horizontal",
# "h-square", "hamburger", "hand-holding-usd", "hand-holding-water",
# "hand-paper", "hand-receiving", "hand-rock", "hands-heart", "hands-helping",
# "hands-usd", "hands-wash", "handshake-alt", "handshake-alt-slash", "hard-hat",
# "hdd", "head-vr", "headphones-alt", "heart-broken", "heart-circle",
# "heart-rate", "heart-square", "heartbeat", "hiking", "history", "home",
# "home-alt", "home-heart", "home-lg", "home-lg-alt", "hospital-alt",
# "hospital-symbol", "hot-tub", "hourglass-half", "house-damage", "house-leave",
# "house-return", "hryvnia", "humidity", "icons-alt", "id-card-alt",
# "industry-alt", "info-circle", "info-square", "innosoft", "inventory",
# "journal-whills", "kiss", "kiss-beam", "kiss-wink-heart", "landmark-alt",
# "laptop-house", "laugh", "laugh-beam", "laugh-squint", "laugh-wink",
# "level-down", "level-down-alt", "level-up", "level-up-alt", "location",
# "location-circle", "location-slash", "lock-alt", "lock-open-alt",
# "long-arrow-alt-down", "long-arrow-alt-left", "long-arrow-alt-right",
# "long-arrow-alt-up", "long-arrow-down", "long-arrow-left", "long-arrow-right",
# "long-arrow-up", "low-vision", "luchador", "luggage-cart", "magic",
# "mail-bulk", "male", "map-marked", "map-marked-alt", "map-marker",
# "map-marker-alt", "map-marker-alt-slash", "map-marker-check",
# "map-marker-edit", "map-marker-exclamation", "map-marker-minus",
# "map-marker-plus", "map-marker-question", "map-marker-slash",
# "map-marker-smile", "map-marker-times", "map-signs", "mars-stroke-h",
# "mars-stroke-v", "medium-m", "medkit", "meh", "meh-blank", "meh-rolling-eyes",
# "microphone-alt", "microphone-alt-slash", "mind-share", "minus-circle",
# "minus-hexagon", "minus-octagon", "minus-square", "mobile-alt",
# "mobile-android", "mobile-android-alt", "money-bill-alt",
# "money-bill-wave-alt", "money-check-alt", "money-check-edit",
# "money-check-edit-alt", "monitor-heart-rate", "mouse", "mouse-alt",
# "mouse-pointer", "music-alt", "music-alt-slash", "oil-temp", "page-break",
# "paint-brush-alt", "pallet-alt", "paragraph-rtl", "parking", "parking-circle",
# "parking-circle-slash", "parking-slash", "pastafarianism", "pause-circle",
# "paw-alt", "pen-alt", "pen-square", "pencil-alt", "pencil-paintbrush",
# "pencil-ruler", "pennant", "people-arrows", "people-carry", "percentage",
# "person-carry", "phone-alt", "phone-laptop", "phone-square",
# "phone-square-alt", "photo-video", "plane-alt", "play-circle", "plus-circle",
# "plus-hexagon", "plus-octagon", "plus-square", "poll", "poll-h",
# "portal-enter", "portal-exit", "portrait", "pound-sign", "pray",
# "praying-hands", "prescription-bottle-alt", "presentation", "print-search",
# "procedures", "project-diagram", "question-circle", "question-square",
# "quran", "rabbit-fast", "radiation-alt", "radio-alt", "random",
# "rectangle-landscape", "rectangle-portrait", "redo", "redo-alt",
# "remove-format", "repeat-1-alt", "repeat-alt", "retweet-alt", "rss-square",
# "running", "sad-cry", "sad-tear", "save", "sax-hot", "scalpel-path",
# "scanner-image", "search", "search-dollar", "search-location", "search-minus",
# "search-plus", "sensor-alert", "sensor-smoke", "share-alt",
# "share-alt-square", "share-square", "shield-alt", "shipping-fast",
# "shipping-timed", "shopping-bag", "shopping-basket", "shopping-cart",
# "shuttle-van", "sign", "sign-in", "sign-in-alt", "sign-language", "sign-out",
# "sign-out-alt", "signal-1", "signal-2", "signal-3", "signal-4", "signal-alt",
# "signal-alt-1", "signal-alt-2", "signal-alt-3", "signal-alt-slash", "skating",
# "ski-jump", "ski-lift", "skiing", "skiing-nordic", "slack-hash", "sledding",
# "sliders-h", "sliders-h-square", "sliders-v", "sliders-v-square", "smile",
# "smile-beam", "smile-plus", "smile-wink", "smoking-ban", "sms",
# "snowboarding", "snowmobile", "sort-alpha-down", "sort-alpha-down-alt",
# "sort-alpha-up", "sort-alpha-up-alt", "sort-alt", "sort-amount-down",
# "sort-amount-down-alt", "sort-amount-up", "sort-amount-up-alt", "sort-circle",
# "sort-circle-down", "sort-circle-up", "sort-numeric-down",
# "sort-numeric-down-alt", "sort-numeric-up", "sort-numeric-up-alt",
# "sort-shapes-down", "sort-shapes-down-alt", "sort-shapes-up",
# "sort-shapes-up-alt", "sort-size-down", "sort-size-down-alt", "sort-size-up",
# "sort-size-up-alt", "soup", "space-shuttle", "space-station-moon-alt",
# "square-root-alt", "star-half-alt", "starfighter-alt", "step-backward",
# "step-forward", "sticky-note", "stop-circle", "store-alt", "store-alt-slash",
# "stream", "subway", "surprise", "swimmer", "swimming-pool", "sync",
# "sync-alt", "table-tennis", "tablet-alt", "tablet-android",
# "tablet-android-alt", "tachometer", "tachometer-alt",
# "tachometer-alt-average", "tachometer-alt-fast", "tachometer-alt-fastest",
# "tachometer-alt-slow", "tachometer-alt-slowest", "tachometer-average",
# "tachometer-fast", "tachometer-fastest", "tachometer-slow",
# "tachometer-slowest", "tanakh", "tasks", "tasks-alt", "telegram-plane",
# "temperature-down", "temperature-frigid", "temperature-hot", "temperature-up",
# "tenge", "th", "th-large", "th-list", "theater-masks", "thermometer-empty",
# "thermometer-full", "thermometer-half", "thermometer-quarter",
# "thermometer-three-quarters", "thunderstorm", "thunderstorm-moon",
# "thunderstorm-sun", "ticket-alt", "times", "times-circle", "times-hexagon",
# "times-octagon", "times-square", "tint", "tint-slash", "tired",
# "toilet-paper-alt", "tombstone-alt", "tools", "torah", "tram",
# "transgender-alt", "trash-alt", "trash-restore", "trash-restore-alt",
# "trash-undo-alt", "tree-alt", "triangle-music", "trophy-alt", "truck-couch",
# "truck-loading", "tshirt", "tv-alt", "undo", "undo-alt", "university",
# "unlink", "unlock-alt", "usd-circle", "usd-square", "user-alt",
# "user-alt-slash", "user-chart", "user-circle", "user-cog", "user-edit",
# "user-friends", "user-hard-hat", "user-md", "user-md-chat", "user-times",
# "users-class", "users-cog", "users-crown", "utensil-fork", "utensil-knife",
# "utensil-spoon", "utensils-alt", "vhs", "volleyball-ball", "volume-down",
# "volume-mute", "volume-up", "vote-nay", "vote-yea", "walking",
# "warehouse-alt", "washer", "water-lower", "water-rise", "waveform-path",
# "webcam", "webcam-slash", "weight", "wifi-1", "wifi-2", "window-alt",
# "window-close", "wine-glass-alt" ), new_name = c( "address-book",
# "address-card", "chart-area", "circle-down", "circle-left", "circle-right",
# "circle-up", "up-down-left-right", "maximize", "left-right", "up-down",
# "hands-asl-interpreting", "car", "chart-bar", "chart-bar", "bath",
# "battery-full", "battery-empty", "battery-quarter", "battery-half",
# "battery-three-quarters", "battery-full", "bell", "bell-slash", "bitbucket",
# "btc", "bookmark", "building", "taxi", "calendar-days", "calendar-check",
# "calendar-minus", "calendar", "calendar-plus", "calendar-xmark",
# "square-caret-down", "square-caret-left", "square-caret-right",
# "square-caret-up", "closed-captioning", "link", "link-slash", "circle-check",
# "square-check", "circle", "circle-notch", "circle", "clock", "xmark",
# "cloud-arrow-down", "cloud-arrow-up", "yen-sign", "code-branch", "comment",
# "comment-dots", "comment-dots", "comments",
# "down-left-and-up-right-to-center", "credit-card", "utensils", "gauge",
# "ear-deaf", "outdent", "gem", "dollar-sign", "circle-dot", "id-card",
# "id-card", "sellcast", "envelope", "envelope-open", "euro-sign", "euro-sign",
# "right-left", "up-right-and-down-left-from-center", "up-right-from-square",
# "square-up-right", "eye-dropper", "font-awesome", "facebook-f", "facebook",
# "rss", "file-zipper", "file-audio", "file-code", "file-excel", "file-image",
# "file-video", "file", "file-pdf", "file-image", "file-image",
# "file-powerpoint", "file-audio", "file-lines", "file-lines", "file-video",
# "file-word", "file-zipper", "copy", "flag", "bolt", "floppy-disk", "folder",
# "folder-open", "face-frown", "futbol", "sterling-sign", "empire", "gratipay",
# "martini-glass-empty", "google-plus-g", "google-plus", "google-plus", "users",
# "hand-back-fist", "hand-lizard", "hand-point-down", "hand-point-left",
# "hand-point-right", "hand-point-up", "hand", "hand-peace", "hand-pointer",
# "hand-back-fist", "hand-scissors", "hand-spock", "hand", "handshake",
# "ear-deaf", "hard-drive", "heading", "heart", "hospital", "bed",
# "hourglass-start", "hourglass", "hourglass-end", "hourglass", "id-card",
# "shekel-sign", "rupee-sign", "building-columns", "transgender", "yen-sign",
# "keyboard", "won-sign", "gavel", "lemon", "turn-down", "turn-up", "life-ring",
# "life-ring", "life-ring", "lightbulb", "chart-line", "linkedin-in",
# "linkedin", "rectangle-list", "down-long", "left-long", "right-long",
# "up-long", "share", "reply", "reply-all", "location-dot", "map",
# "font-awesome", "face-meh", "square-minus", "mobile-screen-button",
# "mobile-screen-button", "money-bill-1", "moon", "graduation-cap", "bars",
# "newspaper", "paper-plane", "clipboard", "circle-pause", "square-pen",
# "pen-to-square", "image", "image", "chart-pie", "circle-play", "square-plus",
# "circle-question", "rebel", "arrows-rotate", "xmark", "bars",
# "arrow-rotate-right", "rebel", "yen-sign", "arrow-rotate-left",
# "arrow-rotate-right", "ruble-sign", "ruble-sign", "ruble-sign", "rupee-sign",
# "bath", "paper-plane", "paper-plane", "share-from-square", "shekel-sign",
# "shekel-sign", "shield-blank", "right-to-bracket", "right-from-bracket",
# "hands", "face-smile", "snapchat", "snowflake", "futbol", "arrow-down-a-z",
# "arrow-down-z-a", "arrow-down-wide-short", "arrow-down-short-wide", "sort-up",
# "sort-down", "arrow-down-1-9", "arrow-down-9-1", "square", "star-half",
# "star-half", "star-half", "star", "note-sticky", "circle-stop", "sun",
# "life-ring", "tablet-screen-button", "gauge", "tv", "temperature-full",
# "temperature-empty", "temperature-quarter", "temperature-half",
# "temperature-three-quarters", "temperature-full", "thumbtack", "thumbs-down",
# "thumbs-up", "ticket-simple", "circle-xmark", "rectangle-xmark",
# "rectangle-xmark", "square-caret-down", "square-caret-left",
# "square-caret-right", "square-caret-up", "trash-can", "trash-can",
# "lira-sign", "lira-sign", "sort", "dollar-sign", "circle-user", "user",
# "address-card", "address-card", "video", "vimeo-v", "phone-volume",
# "triangle-exclamation", "weixin", "accessible-icon", "rectangle-xmark",
# "won-sign", "hacker-news", "y-combinator", "hacker-news", "yen-sign",
# "youtube", "rectangle-ad", "circle-half-stroke", "spray-can-sparkles",
# "alien-8bit", "hand-dots", "truck-medical", "hands-asl-interpreting",
# "chart-mixed", "angles-down", "angles-left", "angles-right", "angles-up",
# "face-angry", "apple-whole", "crate-apple", "box-archive", "circle-down",
# "circle-left", "circle-right", "circle-up", "down", "up-from-line",
# "right-from-line", "left-from-line", "down-from-line", "left", "right",
# "square-down", "square-left", "square-right", "square-up", "down-to-line",
# "left-to-line", "right-to-line", "up-to-line", "up", "circle-arrow-down",
# "circle-arrow-left", "circle-arrow-right", "circle-arrow-up",
# "arrow-up-from-line", "arrow-right-from-line", "arrow-left-from-line",
# "arrow-down-from-line", "square-arrow-down", "square-arrow-left",
# "square-arrow-right", "square-arrow-up", "arrow-down-to-line",
# "arrow-left-to-line", "arrow-right-to-line", "arrow-up-to-line",
# "arrows-up-down-left-right", "up-down-left-right", "left-right", "up-down",
# "arrows-left-right", "arrows-up-down", "ear-listen", "book-atlas",
# "atom-simple", "delete-left", "scale-balanced", "scale-unbalanced",
# "scale-unbalanced-flip", "bandage", "rectangle-barcode", "baseball",
# "basketball", "bed-front", "beer-mug-empty", "cassette-betamax", "book-bible",
# "person-biking", "person-biking-mountain", "cake-candles",
# "person-walking-with-cane", "book-blank", "book-skull", "book-open-reader",
# "book-sparkles", "border-top-left", "border-bottom-right", "box-taped",
# "square-fragile", "box-open-full", "square-this-way-up", "box-dollar",
# "boxes-stacked", "boxes-stacked", "brackets-square", "tower-broadcast",
# "fire-flame-simple", "bus-simple", "calculator-simple", "calendar-days",
# "calendar-pen", "calendar-xmark", "camera", "camera-security", "car-rear",
# "car-burst", "car-wrench", "caravan-simple", "circle-caret-down",
# "circle-caret-left", "circle-caret-right", "circle-caret-up",
# "square-caret-down", "square-caret-left", "square-caret-right",
# "square-caret-up", "camera-cctv", "chalkboard-user", "chart-pie-simple",
# "circle-check", "square-check", "burger-cheese", "chess-bishop-piece",
# "chess-clock-flip", "chess-king-piece", "chess-knight-piece",
# "chess-pawn-piece", "chess-queen-piece", "chess-rook-piece",
# "circle-chevron-down", "circle-chevron-left", "circle-chevron-right",
# "circle-chevron-up", "chevrons-down", "chevrons-left", "chevrons-right",
# "chevrons-up", "square-chevron-down", "square-chevron-left",
# "square-chevron-right", "square-chevron-up", "house-chimney-medical",
# "cloud-arrow-down", "cloud-arrow-up", "martini-glass-citrus", "mug-saucer",
# "cup-togo", "gear", "gears", "table-columns", "message", "message-check",
# "message-dollar", "message-dots", "message-pen", "message-exclamation",
# "message-lines", "message-medical", "message-minus", "message-music",
# "message-plus", "message-slash", "message-smile", "message-xmark",
# "comment-pen", "comment-xmark", "messages", "messages-dollar",
# "down-left-and-up-right-to-center", "minimize", "bell-concierge",
# "triangle-person-digging", "conveyor-belt-boxes", "cowbell-circle-plus",
# "cricket-bat-ball", "crop-simple", "curling-stone", "scissors", "ear-deaf",
# "ban-bug", "desktop", "droplet-degree", "person-dots-from-line",
# "person-digging", "tachograph-digital", "diamond-turn-right", "face-dizzy",
# "cart-flatbed", "cart-flatbed-boxes", "cart-flatbed-empty",
# "circle-dollar-to-slot", "circle-dot", "compass-drafting", "drone-front",
# "dryer-heat", "moon-over-sun", "pen-to-square", "ellipsis", "ellipsis-stroke",
# "ellipsis-vertical", "ellipsis-stroke-vertical", "square-envelope",
# "arrow-right-arrow-left", "right-left", "circle-exclamation",
# "square-exclamation", "triangle-exclamation",
# "up-right-and-down-left-from-center", "arrows-maximize", "maximize",
# "arrow-up-right-from-square", "up-right-from-square", "square-arrow-up-right",
# "square-up-right", "backward-fast", "forward-fast", "feather-pointed",
# "person-dress", "field-hockey-stick-ball", "jet-fighter", "file-lines",
# "file-zipper", "file-chart-column", "file-arrow-down", "file-pen",
# "file-waveform", "file-magnifying-glass", "file-xmark", "file-arrow-up",
# "film-simple", "fire-flame-curved", "kit-medical", "hand-fist",
# "flag-swallowtail", "fire-flame", "flask-round-poison", "flask-round-potion",
# "face-flushed", "cloud-fog", "folder-arrow-down", "folder-xmark",
# "folder-arrow-up", "square-font-awesome-stroke", "font-awesome",
# "font-awesome", "football", "wine-glass-crack", "snowman-head", "face-frown",
# "face-frown-open", "filter-circle-dollar", "game-board-simple",
# "gamepad-modern", "champagne-glass", "champagne-glasses",
# "martini-glass-empty", "martini-glass", "whiskey-glass", "whiskey-glass-ice",
# "glasses-round", "earth-africa", "earth-americas", "earth-asia",
# "earth-europa", "golf-ball-tee", "face-grimace", "face-grin",
# "face-grin-wide", "face-grin-beam", "face-grin-beam-sweat",
# "face-grin-hearts", "face-grin-squint", "face-grin-squint-tears",
# "face-grin-stars", "face-grin-tears", "face-grin-tongue",
# "face-grin-tongue-squint", "face-grin-tongue-wink", "face-grin-wink", "grip",
# "square-h", "burger", "hand-holding-dollar", "hand-holding-droplet", "hand",
# "hands-holding-diamond", "hand-back-fist", "hands-holding-heart",
# "handshake-angle", "hands-holding-dollar", "hands-bubbles",
# "handshake-simple", "handshake-simple-slash", "helmet-safety", "hard-drive",
# "head-side-goggles", "headphones-simple", "heart-crack", "circle-heart",
# "wave-pulse", "square-heart", "heart-pulse", "person-hiking",
# "clock-rotate-left", "house", "house", "house-heart", "house-chimney",
# "house", "hospital", "circle-h", "hot-tub-person", "hourglass",
# "house-chimney-crack", "house-person-leave", "house-person-return",
# "hryvnia-sign", "droplet-percent", "symbols", "id-card-clip",
# "industry-windows", "circle-info", "square-info", "42-group", "shelves",
# "book-journal-whills", "face-kiss", "face-kiss-beam", "face-kiss-wink-heart",
# "landmark-dome", "house-laptop", "face-laugh", "face-laugh-beam",
# "face-laugh-squint", "face-laugh-wink", "arrow-turn-down", "turn-down",
# "arrow-turn-up", "turn-up", "location-crosshairs", "circle-location-arrow",
# "location-crosshairs-slash", "lock-keyhole", "lock-keyhole-open", "down-long",
# "left-long", "right-long", "up-long", "arrow-down-long", "arrow-left-long",
# "arrow-right-long", "arrow-up-long", "eye-low-vision", "luchador-mask",
# "cart-flatbed-suitcase", "wand-magic", "envelopes-bulk", "person",
# "map-location", "map-location-dot", "location-pin", "location-dot",
# "location-dot-slash", "location-check", "location-pen",
# "location-exclamation", "location-minus", "location-plus",
# "location-question", "location-pin-slash", "location-smile", "location-xmark",
# "signs-post", "mars-stroke-right", "mars-stroke-up", "medium",
# "suitcase-medical", "face-meh", "face-meh-blank", "face-rolling-eyes",
# "microphone-lines", "microphone-lines-slash", "brain-arrow-curved-right",
# "circle-minus", "hexagon-minus", "octagon-minus", "square-minus",
# "mobile-screen-button", "mobile", "mobile-screen", "money-bill-1",
# "money-bill-1-wave", "money-check-dollar", "money-check-pen",
# "money-check-dollar-pen", "monitor-waveform", "computer-mouse",
# "computer-mouse-scrollwheel", "arrow-pointer", "music-note",
# "music-note-slash", "oil-temperature", "file-dashed-line", "paint-brush-fine",
# "pallet-boxes", "paragraph-left", "square-parking", "circle-parking",
# "ban-parking", "square-parking-slash", "spaghetti-monster-flying",
# "circle-pause", "paw-simple", "pen-clip", "square-pen", "pencil",
# "pen-paintbrush", "pen-ruler", "flag-pennant", "people-arrows-left-right",
# "people-carry-box", "percent", "person-carry-box", "phone-flip",
# "laptop-mobile", "square-phone", "square-phone-flip", "photo-film",
# "plane-engines", "circle-play", "circle-plus", "hexagon-plus", "octagon-plus",
# "square-plus", "square-poll-vertical", "square-poll-horizontal",
# "person-to-portal", "person-from-portal", "image-portrait", "sterling-sign",
# "person-praying", "hands-praying", "prescription-bottle-medical",
# "presentation-screen", "print-magnifying-glass", "bed-pulse",
# "diagram-project", "circle-question", "square-question", "book-quran",
# "rabbit-running", "circle-radiation", "radio-tuner", "shuffle", "rectangle",
# "rectangle-vertical", "arrow-rotate-right", "rotate-right", "text-slash",
# "arrows-repeat-1", "arrows-repeat", "arrows-retweet", "square-rss",
# "person-running", "face-sad-cry", "face-sad-tear", "floppy-disk",
# "saxophone-fire", "scalpel-line-dashed", "scanner", "magnifying-glass",
# "magnifying-glass-dollar", "magnifying-glass-location",
# "magnifying-glass-minus", "magnifying-glass-plus",
# "sensor-triangle-exclamation", "sensor-cloud", "share-nodes",
# "square-share-nodes", "share-from-square", "shield-blank", "truck-fast",
# "truck-clock", "bag-shopping", "basket-shopping", "cart-shopping",
# "van-shuttle", "sign-hanging", "arrow-right-to-bracket", "right-to-bracket",
# "hands", "arrow-right-from-bracket", "right-from-bracket", "signal-weak",
# "signal-fair", "signal-good", "signal-strong", "signal-bars",
# "signal-bars-weak", "signal-bars-fair", "signal-bars-good",
# "signal-bars-slash", "person-skating", "person-ski-jumping",
# "person-ski-lift", "person-skiing", "person-skiing-nordic", "slack",
# "person-sledding", "sliders", "square-sliders", "sliders-up",
# "square-sliders-vertical", "face-smile", "face-smile-beam", "face-smile-plus",
# "face-smile-wink", "ban-smoking", "comment-sms", "person-snowboarding",
# "person-snowmobiling", "arrow-down-a-z", "arrow-down-z-a", "arrow-up-a-z",
# "arrow-up-z-a", "arrow-down-arrow-up", "arrow-down-wide-short",
# "arrow-down-short-wide", "arrow-up-wide-short", "arrow-up-short-wide",
# "circle-sort", "circle-sort-down", "circle-sort-up", "arrow-down-1-9",
# "arrow-down-9-1", "arrow-up-1-9", "arrow-up-9-1",
# "arrow-down-triangle-square", "arrow-down-square-triangle",
# "arrow-up-triangle-square", "arrow-up-square-triangle",
# "arrow-down-big-small", "arrow-down-small-big", "arrow-up-big-small",
# "arrow-up-small-big", "bowl-hot", "shuttle-space",
# "space-station-moon-construction", "square-root-variable", "star-half-stroke",
# "starfighter-twin-ion-engine", "backward-step", "forward-step", "note-sticky",
# "circle-stop", "shop", "shop-slash", "bars-staggered", "train-subway",
# "face-surprise", "person-swimming", "water-ladder", "arrows-rotate", "rotate",
# "table-tennis-paddle-ball", "tablet-screen-button", "tablet", "tablet-screen",
# "gauge-simple", "gauge", "gauge-med", "gauge", "gauge-max", "gauge-low",
# "gauge-min", "gauge-simple-med", "gauge-simple", "gauge-simple-max",
# "gauge-simple-low", "gauge-simple-min", "book-tanakh", "list-check",
# "bars-progress", "telegram", "temperature-arrow-down", "temperature-snow",
# "temperature-sun", "temperature-arrow-up", "tenge-sign", "table-cells",
# "table-cells-large", "table-list", "masks-theater", "temperature-empty",
# "temperature-full", "temperature-half", "temperature-quarter",
# "temperature-three-quarters", "cloud-bolt", "cloud-bolt-moon",
# "cloud-bolt-sun", "ticket-simple", "xmark", "circle-xmark", "hexagon-xmark",
# "octagon-xmark", "square-xmark", "droplet", "droplet-slash", "face-tired",
# "toilet-paper-blank", "tombstone-blank", "screwdriver-wrench", "scroll-torah",
# "train-tram", "transgender", "trash-can", "trash-arrow-up",
# "trash-can-arrow-up", "trash-can-undo", "tree-deciduous",
# "triangle-instrument", "trophy-star", "truck-ramp-couch", "truck-ramp-box",
# "shirt", "tv", "arrow-rotate-left", "rotate-left", "building-columns",
# "link-slash", "unlock-keyhole", "circle-dollar", "square-dollar",
# "user-large", "user-large-slash", "chart-user", "circle-user", "user-gear",
# "user-pen", "user-group", "user-helmet-safety", "user-doctor",
# "user-doctor-message", "user-xmark", "screen-users", "users-gear",
# "user-group-crown", "fork", "knife", "spoon", "fork-knife", "cassette-vhs",
# "volleyball", "volume-low", "volume-xmark", "volume-high", "xmark-to-slot",
# "check-to-slot", "person-walking", "warehouse-full", "washing-machine",
# "water-arrow-down", "water-arrow-up", "waveform-lines", "camera-web",
# "camera-web-slash", "weight-scale", "wifi-weak", "wifi-fair", "window-flip",
# "rectangle-xmark", "wine-glass-empty" ) ), row.names = c(NA,-945L), class =
# c("data.table", "data.frame") )
```

