### PR TITLE
Update module-selectizeGroup.R

### DIFF
--- a/R/module-selectizeGroup.R
+++ b/R/module-selectizeGroup.R
@@ -37,6 +37,8 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
           X = seq_along(params),
           FUN = function(x) {
             input <- params[[x]]
+            input$options$onInitialize <- I('function() { this.setValue(""); }')
+            input$options$plugins <- union(as.list(input$options$plugins), "remove_button")
             tagSelect <- tags$div(
               class = "btn-group",
               id = ns(paste0("container-", input$inputId)),
@@ -46,12 +48,8 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
                 choices = input$choices,
                 selected = input$selected,
                 multiple = ifelse(is.null(input$multiple), TRUE, input$multiple),
-                width = "100%",
-                options = list(
-                  placeholder = input$placeholder,
-                  plugins = list("remove_button"),
-                  onInitialize = I('function() { this.setValue(""); }')
-                )
+                width = ifelse(is.null(input$width), "100%", input$width),
+                options = input$options
               )
             )
             return(tagSelect)
@@ -72,6 +70,8 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
         X = seq_along(params),
         FUN = function(x) {
           input <- params[[x]]
+          input$options$onInitialize <- I('function() { this.setValue(""); }')
+          input$options$plugins <- union(as.list(input$options$plugins), "remove_button")
           tagSelect <- tags$div(
             id = ns(paste0("container-", input$inputId)),
             selectizeInput(
@@ -80,12 +80,8 @@ selectizeGroupUI <- function(id, params, label = NULL, btn_label = "Reset filter
               choices = input$choices,
               selected = input$selected,
               multiple = ifelse(is.null(input$multiple), TRUE, input$multiple),
-              width = "100%",
-              options = list(
-                placeholder = input$placeholder,
-                plugins = list("remove_button"),
-                onInitialize = I('function() { this.setValue(""); }')
-              )
+              width = ifelse(is.null(input$width), "100%", input$width),
+              options = input$options
             )
           )
           return(tagSelect)


### PR DESCRIPTION
Allow passing width and options as params.

Example:

```
library(shiny)
library(shinyWidgets)

data("mpg", package = "ggplot2")

ui <- fluidPage(
  fluidRow(
    column(
      width = 10, offset = 1,
      tags$h3("Filter data with selectize group"),
      panel(
        selectizeGroupUI(
          id = "my-filters",
          params = list(
            manufacturer = list(inputId = "manufacturer", title = "Manufacturer:", choices = c("audi", "ford"), selected = "ford", multiple = FALSE),
            model = list(inputId = "model", title = "Model:", options = list(placeholder = "test", plugins = list("drag_drop")), selected = "mustang"),
            trans = list(inputId = "trans", title = "Trans:", options = list(placeholder = "test", plugins = list("drag_drop"))),
            class = list(inputId = "class", title = "Class:", width = "50%")
          ),
          inline = FALSE
        ), status = "primary"
      ),
      DT::dataTableOutput(outputId = "table")
    )
  )
)

server <- function(input, output, session) {
  res_mod <- callModule(
    module = selectizeGroupServer,
    id = "my-filters",
    data = mpg,
    vars = c("manufacturer", "model", "trans", "class"),
    inline = FALSE
  )
  output$table <- DT::renderDataTable({res_mod()})
}

shinyApp(ui, server)
```