### PR TITLE
VirtualSelectInput Inline

### DIFF
--- a/R/virtual-select.R
+++ b/R/virtual-select.R
@@ -155,24 +155,35 @@ virtualSelectInput <- function(inputId,
   data <- toJSON(data, auto_unbox = TRUE, json_verbatim = TRUE)
   if (isTRUE(html))
     data <- HTML(data)
+
+  if (!inline) {
+    div_css <- css(
+      width = "100%",
+      maxWidth = "none",
+      display = "block"
+    )
+  } else {
+    div_css <- css(
+      display = "inline-block"
+    )
+  }
   tags$div(
     class = "form-group shiny-input-container",
+    class = if (isTRUE(inline)) "shiny-input-container-inline",
     style = css(width = validateCssUnit(width)),
+    style = if (isTRUE(inline)) "display: inline-block;",
     tags$label(
       label,
       class = "control-label",
       class = if (is.null(label)) "shiny-label-null",
       id = paste0(inputId, "-label"),
+      style = if (isTRUE(inline)) "display: inline-block;",
       `for` = inputId
     ),
     tags$div(
       id = inputId,
       class = "virtual-select",
-      style = css(
-        width = "100%",
-        maxWidth = "none",
-        display = if (!inline) "block"
-      ),
+      style = div_css,
       tags$script(
         type = "application/json",
         `data-for` = inputId,

--- a/R/virtual-select.R
+++ b/R/virtual-select.R
@@ -171,13 +171,11 @@ virtualSelectInput <- function(inputId,
     class = "form-group shiny-input-container",
     class = if (isTRUE(inline)) "shiny-input-container-inline",
     style = css(width = validateCssUnit(width)),
-    style = if (isTRUE(inline)) "display: inline-block;",
     tags$label(
       label,
       class = "control-label",
       class = if (is.null(label)) "shiny-label-null",
       id = paste0(inputId, "-label"),
-      style = if (isTRUE(inline)) "display: inline-block;",
       `for` = inputId
     ),
     tags$div(


### PR DESCRIPTION
Inline wasn't working as expected (still the label is on top of the dropdown), so I added some additional `inline` areas mirrored after `pickerInput`.  I can't get it to do exactly what I want until I set `width = "100%"` but it does have the desired effect.