### PR TITLE
Change airDatepickerInput's button display to table-cell

### DIFF
--- a/R/input-airDatepicker.R
+++ b/R/input-airDatepicker.R
@@ -215,8 +215,7 @@ airDatepickerInput <- function(inputId,
         class = "input-group",
         if (identical(addon, "left")) {
           tags$div(
-            style = "display: table-cell;",
-            class = "btn action-button input-group-addon",
+            class = "btn action-button input-group-addon dp-addon",
             id = paste0(inputId, "_button"),
             icon("calendar-days")
           )
@@ -224,8 +223,7 @@ airDatepickerInput <- function(inputId,
         tagAir,
         if (identical(addon, "right")) {
           tags$div(
-            style = "display: table-cell;",
-            class = "btn action-button input-group-addon",
+            class = "btn action-button input-group-addon dp-addon",
             id = paste0(inputId, "_button"),
             icon("calendar-days")
           )

--- a/R/input-airDatepicker.R
+++ b/R/input-airDatepicker.R
@@ -215,6 +215,7 @@ airDatepickerInput <- function(inputId,
         class = "input-group",
         if (identical(addon, "left")) {
           tags$div(
+            style = "display: table-cell;",
             class = "btn action-button input-group-addon",
             id = paste0(inputId, "_button"),
             icon("calendar-days")
@@ -223,6 +224,7 @@ airDatepickerInput <- function(inputId,
         tagAir,
         if (identical(addon, "right")) {
           tags$div(
+            style = "display: table-cell;",
             class = "btn action-button input-group-addon",
             id = paste0(inputId, "_button"),
             icon("calendar-days")

--- a/srcjs/css/air-datepicker.css
+++ b/srcjs/css/air-datepicker.css
@@ -25,3 +25,8 @@
   background: #fff;
   opacity: 0.5;
 }
+
+/* For addon buttons */
+.btn.action-button.input-group-addon.dp-addon {
+  display: table-cell;
+}


### PR DESCRIPTION
# Reason for change
When using `airDatepickerInput` in sidebars and enabling the `addon` button, the widget's display breaks down. The button is not attached to the input, and sometimes it doesn't get colored properly. This happens in the sidebar, but not in the main body. Noticed when used in `shinydashboard::dashboardPage()`.

# Bug screenshot
I've attached an example of the behavior before and after changes in this PR.
<img width="899" alt="comparison" src="https://github.com/dreamRs/shinyWidgets/assets/111303584/b707ad12-3e87-4b8c-9ed3-6b7fb2c74221">


# Code Example
Try this app and check the layout in the current build. Then compare it with the version in this PR.
```
library(shiny)
library(shinyWidgets)
library(shinydashboard)

ui <- dashboardPage(
  dashboardHeader(),
  dashboardSidebar(
    airDatepickerInput(inputId = "side_left", addon = "left"),
    airDatepickerInput(inputId = "side_right", addon = "right")
    ),
  dashboardBody(
    airDatepickerInput(inputId = "body_left", addon = "left"),
    airDatepickerInput(inputId = "body_right", addon = "right")
    )
)

server <- function(input, output, session) {
  
}

shinyApp(ui, server)
```

## Alternate solution
Instead of change the div style, a CSS class could be added to the divs containing addon buttons. Then the display property could be changed for that class.
Let me know if this is a more preferable solution than inline CSS styling, and I will make this change.