### PR TITLE
Addition of autocomplete parameter

### DIFF
--- a/R/input-multi.R
+++ b/R/input-multi.R
@@ -10,6 +10,7 @@
 #' @param choiceNames List of names to display to the user.
 #' @param choiceValues List of values corresponding to \code{choiceNames}.
 #' @param options List of options passed to multi (\code{enable_search = FALSE} for disabling the search bar for example).
+#' @param autocomplete Sets the initial state of the autocomplete property.
 #'
 #' @return A multiselect control that can be added to the UI of a shiny app.
 #'
@@ -89,16 +90,18 @@ multiInput <- function(inputId,
                        options = NULL,
                        width = NULL,
                        choiceNames = NULL,
-                       choiceValues = NULL) {
+                       choiceValues = NULL,
+                       autocomplete = FALSE) {
   selected <- shiny::restoreInput(id = inputId, default = selected)
   selectTag <- tags$select(
-    id = inputId, multiple = "multiple", class= "form-control multijs",
+    id = inputId, multiple = "multiple", class = "form-control multijs",
     makeChoices(
       choices = choices,
       choiceNames = choiceNames,
       choiceValues = choiceValues,
       selected = selected
-    )
+    ),
+    autocomplete = if (autocomplete) "on" else "off"
   )
   tags$div(
     class = "form-group shiny-input-container",

--- a/R/input-selectpicker.R
+++ b/R/input-selectpicker.R
@@ -25,6 +25,7 @@
 #' @param width The width of the input : 'auto', 'fit', '100px', '75%'.
 #' @param inline Display picker inline, to have label and menu on same line use `width = "fit"`.
 #' @param stateInput Activate or deactivate the special input value `input$<inputId>_open` to know if the menu is opened or not, see details.
+#' @param autocomplete Sets the initial state of the autocomplete property.
 #'
 #' @seealso [updatePickerInput] to update value server-side. [virtualSelectInput()] for an alternative.
 #'
@@ -85,7 +86,8 @@ pickerInput <- function(inputId,
                         choicesOpt = NULL,
                         width = NULL,
                         inline = FALSE,
-                        stateInput = TRUE) {
+                        stateInput = TRUE,
+                        autocomplete = FALSE) {
   choices <- choicesWithNames(choices)
   selected <- restoreInput(id = inputId, default = selected)
   if (!is.null(options) && length(options) > 0)
@@ -109,7 +111,8 @@ pickerInput <- function(inputId,
   selectTag <- tagAppendAttributes(
     tag = selectTag,
     id = inputId,
-    class = "selectpicker form-control"
+    class = "selectpicker form-control",
+    autocomplete = if (autocomplete) "on" else "off"
   )
   selectTag <- tagAppendChildren(
     tag = selectTag,

--- a/man/multiInput.Rd
+++ b/man/multiInput.Rd
@@ -12,7 +12,8 @@ multiInput(
   options = NULL,
   width = NULL,
   choiceNames = NULL,
-  choiceValues = NULL
+  choiceValues = NULL,
+  autocomplete = FALSE
 )
 }
 \arguments{
@@ -31,6 +32,8 @@ multiInput(
 \item{choiceNames}{List of names to display to the user.}
 
 \item{choiceValues}{List of values corresponding to \code{choiceNames}.}
+
+\item{autocomplete}{Sets the initial state of the autocomplete property.}
 }
 \value{
 A multiselect control that can be added to the UI of a shiny app.

--- a/man/pickerInput.Rd
+++ b/man/pickerInput.Rd
@@ -14,7 +14,8 @@ pickerInput(
   choicesOpt = NULL,
   width = NULL,
   inline = FALSE,
-  stateInput = TRUE
+  stateInput = TRUE,
+  autocomplete = FALSE
 )
 }
 \arguments{
@@ -51,6 +52,8 @@ each element of the \code{list} should the same length as \code{choices}. You ca
 \item{inline}{Display picker inline, to have label and menu on same line use \code{width = "fit"}.}
 
 \item{stateInput}{Activate or deactivate the special input value \verb{input$<inputId>_open} to know if the menu is opened or not, see details.}
+
+\item{autocomplete}{Sets the initial state of the autocomplete property.}
 }
 \value{
 A select control that can be added to a UI definition.


### PR DESCRIPTION
Hello @pvictor,

First of all, I'm not sure why the whole files are marked as changed because I only updated function parameters, documentation and selectTag creation. If you happen to know why is that I'm happy to redo the PR.

This PR fixes a common Mozila bug as seen for example here:
- https://github.com/rstudio/shiny/issues/3763
- https://github.com/rstudio/shiny/issues/2293

An ease reprex is this code:

```r
library(shiny)
library(shinyWidgets)

ui <- fluidPage(
  pickerInput(
    inputId = "somevalue",
    label = "My label",
    choices = c("a", "b", "c"),
    autocomplete = FALSE
  ),
  multiInput(
    inputId = "somevalue2",
    label = "My label",
    choices = c("a", "b", "c"),
  ),
)

server <- function(input, output, session) { }

shinyApp(ui = ui, server = server)
```

If you run this code in Mozilla, select any picker/multiPicker value and refresh the site, the option is cached and kept on. This can be fixed by adding `autocomplete = "off"` to the HTML element, which is what this PR does.

I only found this issue with these two widgets, but I'm happy to add it to more widgets if you find it appropriate. I can also move the parameter into the options list() - again, what you think fits this package the best :)

Thanks for your development and if any further changes are needed, feel free to let me know.

