### PR TITLE
added classNames as optional arg to prepare_choices

### DIFF
--- a/R/virtual-select.R
+++ b/R/virtual-select.R
@@ -18,6 +18,7 @@ html_dependency_virtualselect <- function() {
 #' @param group_by Variable identifying groups to use option group feature.
 #' @param description Optional variable allowing to show a text under the labels.
 #' @param alias Optional variable containing text to use with search feature.
+#' @param classNames Optional variable containing class names to customize specific options.
 #'
 #' @return A `list` to use as `choices` argument of [virtualSelectInput()].
 #' @export
@@ -30,14 +31,16 @@ prepare_choices <- function(.data,
                             value,
                             group_by = NULL,
                             description = NULL,
-                            alias = NULL) {
+                            alias = NULL,
+                            classNames = NULL) {
   args <- lapply(
     X = enexprs(
       label = label,
       value = value,
       group_by = group_by,
       description = description,
-      alias = alias
+      alias = alias,
+      classNames = classNames
     ),
     FUN = eval_tidy,
     data = as.data.frame(.data)

--- a/man/prepare_choices.Rd
+++ b/man/prepare_choices.Rd
@@ -10,7 +10,8 @@ prepare_choices(
   value,
   group_by = NULL,
   description = NULL,
-  alias = NULL
+  alias = NULL,
+  classNames = NULL
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ prepare_choices(
 \item{description}{Optional variable allowing to show a text under the labels.}
 
 \item{alias}{Optional variable containing text to use with search feature.}
+
+\item{classNames}{Optional variable containing class names to customize specific options.}
 }
 \value{
 A \code{list} to use as \code{choices} argument of \code{\link[=virtualSelectInput]{virtualSelectInput()}}.

--- a/man/shinyWidgets.Rd
+++ b/man/shinyWidgets.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/shinyWidgets.R
 \docType{package}
 \name{shinyWidgets}
-\alias{shinyWidgets-package}
 \alias{shinyWidgets}
+\alias{shinyWidgets-package}
 \title{shinyWidgets: Custom inputs widgets for Shiny.}
 \description{
 The shinyWidgets package provides several custom widgets to extend those available in package shiny


### PR DESCRIPTION
Extending `prepare_choices` with classNames, ref. #658 

Demo:

library(shiny)
library(shinyWidgets)

state_data <- data.frame(
  name = state.name,
  abb = state.abb,
  region = state.region,
  division = state.division,
  class = ifelse(state.region == "South", "red-class bold-class", "")
)

ui <- fluidPage(
  tags$style(".red-class {color: red;} .bold-class {font-weight: 600;}"),
  tags$h2("Virtual Select: prepare choices"),
  
  virtualSelectInput(
    inputId = "sel1",
    label = "Use a data.frame:",
    choices = prepare_choices(state_data, name, abb, classNames = class),
    search = TRUE
  )
)

server <- function(input, output, session) {
  output$res1 <- renderPrint(input$sel1)

}

if (interactive())
  shinyApp(ui, server)