### PR TITLE
Unname "selected" argument in virtualSelectInput and updateVirtualSelect

### DIFF
--- a/R/virtual-select.R
+++ b/R/virtual-select.R
@@ -224,6 +224,8 @@ updateVirtualSelect <- function(inputId,
                                 label = NULL,
                                 choices = NULL,
                                 selected = NULL,
+                                description = NULL,
+                                hasOptionDescription = F,
                                 disable = NULL,
                                 disabledChoices = NULL,
                                 session = shiny::getDefaultReactiveDomain()) {
@@ -231,6 +233,10 @@ updateVirtualSelect <- function(inputId,
     label <- doRenderTags(label)
   if (!is.null(choices)) {
     choices <- process_choices(choices)
+    if (!is.null(description)){
+      choices$choices$description = description
+      hasOptionDescription = TRUE
+    }
     choices <- toJSON(choices, auto_unbox = FALSE, json_verbatim = TRUE)
   }
   message <- dropNulls(list(
@@ -238,6 +244,7 @@ updateVirtualSelect <- function(inputId,
     options = choices,
     value = unname(selected),
     disable = disable,
+    hasOptionDescription = hasOptionDescription,
     disabledChoices = list1(disabledChoices)
   ))
   session$sendInputMessage(inputId, message)


### PR DESCRIPTION
Update to solve the following issue: 

When initializing or updating a virtualSelectInput with multiple = TRUE, I am unable to pass a named list to the selected argument.

The choices argument works properly (initially and on update), but the input renders with no options selected (though I pass in the identical named list as the choices argument)